### PR TITLE
[WIP] Add debug env variable `SHARK_DEBUG`

### DIFF
--- a/shark/torch_mlir_utils.py
+++ b/shark/torch_mlir_utils.py
@@ -127,10 +127,13 @@ def get_torch_mlir_module(
     )
     mb.import_module(module._c, class_annotator)
 
+    passes = "torchscript-module-to-torch-backend-pipeline,torch-backend-to-linalg-on-tensors-backend-pipeline"
+    # Set `SHARK_DEBUG` environment variable to log the intermediate mlir output.
+    if 'SHARK_DEBUG' in os.environ and os.environ['SHARK_DEBUG']:
+        mb.module.dump()
+
     with mb.module.context:
-        pm = PassManager.parse(
-            "torchscript-module-to-torch-backend-pipeline,torch-backend-to-linalg-on-tensors-backend-pipeline"
-        )
+        pm = PassManager.parse(passes)
         pm.run(mb.module)
 
     return mb.module


### PR DESCRIPTION
This commit adds an environment variable `SHARK_DEBUG` in order to log
the intermediate mlir outputs.

Signed-Off-by: Gaurav Shukla <gaurav@nod-labs.com>