### PR TITLE
Refactor get_iree_module to work with SharkBenchmark

### DIFF
--- a/shark/shark_runner.py
+++ b/shark/shark_runner.py
@@ -48,23 +48,18 @@ class SharkRunner:
         if self.frontend in ["pytorch", "torch"]:
             self.model = get_torch_mlir_module(self.model, input, dynamic,
                                                jit_trace, from_aot)
-            (
-            self.iree_compilation_module,
-            self.iree_config,
-            ) = get_iree_compiled_module(self.model, device)
-
-        if self.frontend in ["tensorflow", "tf", "mhlo"]:
-            (
-            self.iree_compilation_module,
-            self.iree_config,
-            ) = get_iree_compiled_module(self.model, device, self.frontend)
+        (
+        self.iree_compilation_module,
+        self.iree_config,
+        ) = get_iree_compiled_module(self.model, device, self.frontend)
 
         # Debugging Options:
         if shark_args.save_mlir:
-            export_module_to_mlir_file(self.model, shark_args.repro_dir)
-        if shark_args.save_mlir:
+            export_module_to_mlir_file(self.model, device, shark_args.repro_dir, self.frontend)
+        if shark_args.save_vmfb:
             self.vmfb_file = export_iree_module_to_vmfb(self.model, device,
-                                                        shark_args.repro_dir)
+                                                        shark_args.repro_dir,
+                                                        frontend)
 
     # All the timings and benchmarking can be done here.
     def forward(self, input, frontend):
@@ -103,7 +98,8 @@ class SharkBenchmarkRunner(SharkRunner):
                              from_aot, frontend)
         if (self.vmfb_file == None):
             self.vmfb_file = export_iree_module_to_vmfb(self.model, device,
-                                                        shark_args.repro_dir)
+                                                        shark_args.repro_dir,
+                                                        frontend)
         self.benchmark_cl = build_benchmark_args(self.vmfb_file, device, input,
                                                  from_aot)
 

--- a/shark/tests/test_benchmark.py
+++ b/shark/tests/test_benchmark.py
@@ -1,0 +1,93 @@
+from shark.shark_inference import SharkInference
+from shark.iree_utils import check_device_drivers
+
+import torch
+import numpy as np
+import torchvision.models as models
+from transformers import AutoModelForSequenceClassification
+import pytest
+
+torch.manual_seed(0)
+
+##################### Hugging Face LM Models ###################################
+
+
+class HuggingFaceLanguage(torch.nn.Module):
+
+    def __init__(self, hf_model_name):
+        super().__init__()
+        self.model = AutoModelForSequenceClassification.from_pretrained(
+            hf_model_name,  # The pretrained model.
+            num_labels=
+            2,  # The number of output labels--2 for binary classification.
+            output_attentions=
+            False,  # Whether the model returns attentions weights.
+            output_hidden_states=
+            False,  # Whether the model returns all hidden-states.
+            torchscript=True,
+        )
+
+    def forward(self, tokens):
+        return self.model.forward(tokens)[0]
+
+
+def get_hf_model(name):
+    model = HuggingFaceLanguage(name)
+    # TODO: Currently the test input is set to (1,128)
+    test_input = torch.randint(2, (1, 128))
+    actual_out = model(test_input)
+    return model, test_input, actual_out
+
+
+################################################################################
+
+##################### Torch Vision Models    ###################################
+
+
+class VisionModule(torch.nn.Module):
+
+    def __init__(self, model):
+        super().__init__()
+        self.model = model
+        self.train(False)
+
+    def forward(self, input):
+        return self.model.forward(input)
+
+
+def get_vision_model(torch_model):
+    model = VisionModule(torch_model)
+    # TODO: Currently the test input is set to (1,128)
+    test_input = torch.randn(1, 3, 224, 224)
+    actual_out = model(test_input)
+    return model, test_input, actual_out
+
+
+#############################   Benchmark Tests ####################################
+
+# Test running benchmark module without failing.
+pytest_benchmark_param = pytest.mark.parametrize(
+    ('dynamic', 'device'),
+    [
+        pytest.param(False, 'cpu'),
+        # TODO: Language models are failing for dynamic case..
+        pytest.param(True, 'cpu', marks=pytest.mark.skip),
+    ])
+
+
+@pytest_benchmark_param
+def test_minilm_torch(dynamic, device):
+    model, test_input, act_out = get_hf_model("microsoft/MiniLM-L12-H384-uncased")
+    shark_module = SharkInference(model, (test_input,),
+                                  device=device,
+                                  dynamic=dynamic,
+                                  jit_trace=True,
+                                  benchmark_mode=True)
+    try:
+        # If becnhmarking succesful, assert success/True.
+        shark_module.compile()
+        shark_module.benchmark_all((test_input,))
+        assert True
+    except Exception as e:
+        # If anything happen during benchmarking, assert False/failure.
+        assert False


### PR DESCRIPTION
1. Refactored get_iree_module to a function that convert mlir->vmfb. (helps with generation of correct vmfb for benchmarking)
2. Added benchmarking test
3. minor cleanups and fix

Example:

```bash
python -m shark.examples.shark_inference.minilm_benchmark --device="cpu"
```