### PR TITLE
Add saving and loading of mlir to run.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -161,4 +161,4 @@ cython_debug/
 #.idea/
 
 # Shark related artefacts
-shark.venv/ 
+shark.venv/

--- a/shark/examples/shark_training/bert_training_load_tf.py
+++ b/shark/examples/shark_training/bert_training_load_tf.py
@@ -1,0 +1,49 @@
+import numpy as np
+import os
+import time
+import tensorflow as tf
+
+from shark.shark_trainer import SharkTrainer
+from shark.parser import parser
+from urllib import request
+
+parser.add_argument(
+    "--download_mlir_path",
+    type=str,
+    default="bert_tf_training.mlir",
+    help="Specifies path to target mlir file that will be loaded.")
+load_args, unknown = parser.parse_known_args()
+
+tf.random.set_seed(0)
+vocab_size = 100
+NUM_CLASSES = 5
+SEQUENCE_LENGTH = 512
+BATCH_SIZE = 1
+
+# Download BERT model from tank and train.
+if __name__ == "__main__":
+    predict_sample_input = [
+        np.random.randint(5, size=(BATCH_SIZE, SEQUENCE_LENGTH)),
+        np.random.randint(5, size=(BATCH_SIZE, SEQUENCE_LENGTH)),
+        np.random.randint(5, size=(BATCH_SIZE, SEQUENCE_LENGTH))
+    ]
+    file_link = "https://storage.googleapis.com/shark_tank/users/stanley/bert_tf_training.mlir"
+    response = request.urlretrieve(file_link, load_args.download_mlir_path)
+    sample_input_tensors = [tf.convert_to_tensor(val, dtype=tf.int32) for val in predict_sample_input]
+    num_iter = 10
+    if not os.path.isfile(load_args.download_mlir_path):
+        raise ValueError(f"Tried looking for target mlir in {load_args.download_mlir_path}, but cannot be found.")
+    with open(load_args.download_mlir_path, "rb") as input_file:
+        bert_mlir = input_file.read()
+    shark_module = SharkTrainer(
+        bert_mlir,
+        (sample_input_tensors,
+         tf.convert_to_tensor(np.random.randint(5, size=(BATCH_SIZE)), dtype=tf.int32)))
+    shark_module.set_frontend("mhlo")
+    shark_module.compile()
+    start = time.time()
+    print(shark_module.train(num_iter))
+    end = time.time()
+    total_time = end - start
+    print("time: " + str(total_time))
+    print("time/iter: " + str(total_time / num_iter))

--- a/shark/examples/shark_training/bert_training_tf.py
+++ b/shark/examples/shark_training/bert_training_tf.py
@@ -13,6 +13,8 @@ from official.nlp.modeling.models import bert_classifier
 
 from shark.shark_trainer import SharkTrainer
 
+
+tf.random.set_seed(0)
 vocab_size = 100
 NUM_CLASSES = 5
 SEQUENCE_LENGTH = 512
@@ -61,7 +63,7 @@ class BertModule(tf.Module):
         variables = self.m.trainable_variables
         gradients = tape.gradient(loss, variables)
         self.optimizer.apply_gradients(zip(gradients, variables))
-        return probs
+        return loss
 
 
 if __name__ == "__main__":

--- a/shark/iree_utils.py
+++ b/shark/iree_utils.py
@@ -205,10 +205,22 @@ def export_iree_module_to_vmfb(module,
     flatbuffer_blob = compile_module_to_flatbuffer(module, device, frontend, func_name, model_config_path)
     module_name = f"{frontend}_{func_name}_{device}"
     filename = os.path.join(directory, module_name + ".vmfb")
+    print(f"Saved vmfb in {filename}.")
     with open(filename, 'wb') as f:
         f.write(flatbuffer_blob)
     return filename
 
+def export_module_to_mlir_file(module, frontend, directory: str):
+    mlir_str = module
+    if frontend in ["tensorflow", "tf", "mhlo"]:
+        mlir_str = module.decode('utf-8')
+    elif frontend in ["pytorch", "torch"]:
+        mlir_str = module.operation.get_asm()
+    filename = os.path.join(directory, "model.mlir")
+    with open(filename, 'w') as f:
+        f.write(mlir_str)
+    print(f"Saved mlir in {filename}.")
+    return filename
 
 def get_results(compiled_vm, input, config, frontend="torch"):
     """Runs a .vmfb file given inputs and config and returns output."""

--- a/shark/parser.py
+++ b/shark/parser.py
@@ -23,6 +23,13 @@ def dir_path(path):
         raise argparse.ArgumentTypeError(
             f"readable_dir:{path} is not a valid path")
 
+def dir_file(path):
+    if os.path.isfile(path):
+        return path
+    else:
+        raise argparse.ArgumentTypeError(
+            f"readable_file:{path} is not a valid file")
+
 
 parser = argparse.ArgumentParser(description='SHARK runner.')
 parser.add_argument(

--- a/shark/shark_runner.py
+++ b/shark/shark_runner.py
@@ -18,8 +18,8 @@ from torch_mlir.eager_mode.torch_mlir_tensor import TorchMLIRTensor
 from torch_mlir_e2e_test.eager_backends.refbackend import EagerModeRefBackend
 
 from shark.iree_eager_backend import EagerModeIREELinalgOnTensorsBackend
-from shark.torch_mlir_utils import get_torch_mlir_module, export_module_to_mlir_file, run_on_refbackend
-from shark.iree_utils import get_results, get_iree_compiled_module, export_iree_module_to_vmfb, build_benchmark_args, run_benchmark
+from shark.torch_mlir_utils import get_torch_mlir_module, run_on_refbackend
+from shark.iree_utils import get_results, get_iree_compiled_module, export_iree_module_to_vmfb, export_module_to_mlir_file, build_benchmark_args, run_benchmark
 import os
 from shark.parser import shark_args
 from tqdm import tqdm
@@ -63,7 +63,7 @@ class SharkRunner:
 
         # Debugging Options:
         if shark_args.save_mlir:
-            export_module_to_mlir_file(self.model, device, shark_args.repro_dir, self.frontend)
+            export_module_to_mlir_file(self.model, self.frontend, shark_args.repro_dir)
         if shark_args.save_vmfb:
             self.vmfb_file = export_iree_module_to_vmfb(self.model, device,
                                                         shark_args.repro_dir,

--- a/shark/torch_mlir_utils.py
+++ b/shark/torch_mlir_utils.py
@@ -44,15 +44,6 @@ def get_module_name_for_asm_dump(module):
         module.operation.attributes["torch.debug_module_name"]).value
 
 
-def export_module_to_mlir_file(module, directory: str):
-    """Writes MLIR module to /tmp/module.mlir for debugging or performance use."""
-    module_name = get_module_name_for_asm_dump(module)
-    asm = module.operation.get_asm()
-    filename = os.path.join(directory, module_name + ".mlir")
-    with open(filename, 'w') as f:
-        f.write(asm)
-
-
 def get_input_annotations(inputs: tuple, dynamic: bool) -> list:
     """TODO: Include necessary documentation"""
 


### PR DESCRIPTION
Added:
-Generalized save_mlir for tensorflow+torch
-Return loss for tf train since that's what we need to observer training 
-Remove return of self.trainable_params isn't updated in the mlir runs.

To try load and save:
```bash
# Saves mlir file to /tmp/model.mlir
python -m shark.examples.shark_training.bert_training_load_tf --device="cpu" --save_mlir
# Runs mlir file in /tmp/model.mlir
python -m shark.examples.shark_training.bert_training_load_tf --device="cpu"
# If you want to download in a specific directory and filename
python -m shark.examples.shark_training.bert_training_load_tf --device="cpu" --download_mlir_path=/tmp/tf_bert.mlir
```
Should work on device of your choice(cpu/gpu/vulkan).