### PR TITLE
Increase IREE LLVM stack alloc limit for dynamic cpu case on Language Models.

### DIFF
--- a/shark/iree_utils.py
+++ b/shark/iree_utils.py
@@ -18,6 +18,7 @@ import iree.compiler as ireec
 from shark.torch_mlir_utils import get_module_name_for_asm_dump
 from shark.cuda_utils import get_cuda_sm_cc
 from shark.model_annotation import *
+from shark.parser import shark_args
 import subprocess
 import numpy as np
 import os
@@ -83,8 +84,14 @@ def get_iree_cpu_args():
     else:
         error_message = f"OS Type f{os_name} not supported and triple can't be determined, open issue to dSHARK team please :)"
         raise Exception(error_message)
-    print(f"Target triple found:{target_triple}")
-    return [f"-iree-llvm-target-triple={target_triple}"]
+    print(f"Target triple found:{target_triple}") 
+    if shark_args.increase_stack_alloc_size == True:
+        return [
+            "--iree-llvmcpu-stack-allocation-limit=131072",
+            f"-iree-llvm-target-triple={target_triple}"
+        ]
+    else:
+        return [f"-iree-llvm-target-triple={target_triple}"]
 
 
 def get_iree_gpu_args():

--- a/shark/parser.py
+++ b/shark/parser.py
@@ -67,5 +67,10 @@ parser.add_argument(
     type=int,
     default=1,
     help="Run the model for the specified number of iterations.")
+parser.add_argument(
+    "--increase_stack_alloc_size",
+    default=False,
+    action="store_true",
+    help="Increases IREE cpu stack allocation size limit from 32KB to 128KB. Should only be used for dynamic cpu case on language models.")
 
 shark_args, unknown = parser.parse_known_args()

--- a/tank/pytorch/MiniLM-L12-H384-uncased/MiniLM-L12-H384-uncased_pytorch_test.py
+++ b/tank/pytorch/MiniLM-L12-H384-uncased/MiniLM-L12-H384-uncased_pytorch_test.py
@@ -18,16 +18,19 @@ class MiniLMModuleTester:
         device="cpu",
         save_mlir=False,
         save_vmfb=False,
+        increase_stack_alloc_size=False,
     ):
         self.dynamic = dynamic
         self.device = device
         self.save_mlir = save_mlir
         self.save_vmfb = save_vmfb
+        self.increase_stack_alloc_size = increase_stack_alloc_size
 
     def create_and_check_module(self):
         model, input, act_out = get_hf_model("microsoft/MiniLM-L12-H384-uncased")
         shark_args.save_mlir = self.save_mlir
         shark_args.save_vmfb = self.save_vmfb
+        shark_args.increase_stack_alloc_size = self.increase_stack_alloc_size
         shark_module = SharkInference(model, (input,),
                                       device=self.device,
                                       dynamic=self.dynamic,
@@ -51,10 +54,10 @@ class MiniLMModuleTest(unittest.TestCase):
         self.module_tester.device = "cpu"
         self.module_tester.create_and_check_module()
     
-    @pytest.mark.xfail(reason="language models failing for dynamic case")
     def test_module_dynamic_cpu(self):
         self.module_tester.dynamic = True
         self.module_tester.device = "cpu"
+        self.module_tester.increase_stack_alloc_size = True
         self.module_tester.create_and_check_module()
     
     @pytest.mark.skipif(check_device_drivers("gpu"), reason="nvidia-smi not found")

--- a/tank/pytorch/albert-base-v2/albert-base-v2_pytorch_test.py
+++ b/tank/pytorch/albert-base-v2/albert-base-v2_pytorch_test.py
@@ -18,16 +18,19 @@ class AlbertModuleTester:
         device="cpu",
         save_mlir=False,
         save_vmfb=False,
+        increase_stack_alloc_size=False,
     ):
         self.dynamic = dynamic
         self.device = device
         self.save_mlir = save_mlir
         self.save_vmfb = save_vmfb
+        self.increase_stack_alloc_size = increase_stack_alloc_size
 
     def create_and_check_module(self):
         model, input, act_out = get_hf_model("albert-base-v2")
         shark_args.save_mlir = self.save_mlir
         shark_args.save_vmfb = self.save_vmfb
+        shark_args.increase_stack_alloc_size = self.increase_stack_alloc_size
         shark_module = SharkInference(model, (input,),
                                       device=self.device,
                                       dynamic=self.dynamic,
@@ -52,10 +55,10 @@ class AlbertModuleTest(unittest.TestCase):
         self.module_tester.device = "cpu"
         self.module_tester.create_and_check_module()
     
-    @pytest.mark.xfail(reason="Language models currently failing for dynamic case")
     def test_module_dynamic_cpu(self):
         self.module_tester.dynamic = True
         self.module_tester.device = "cpu"
+        self.module_tester.increase_stack_alloc_size = True
         self.module_tester.create_and_check_module()
     
     @pytest.mark.skipif(check_device_drivers("gpu"), reason="nvidia-smi not found")

--- a/tank/pytorch/bert-base-uncased/bert-base-uncased_pytorch_test.py
+++ b/tank/pytorch/bert-base-uncased/bert-base-uncased_pytorch_test.py
@@ -18,16 +18,19 @@ class BertModuleTester:
         device="cpu",
         save_mlir=False,
         save_vmfb=False,
+        increase_stack_alloc_size=False,
     ):
         self.dynamic = dynamic
         self.device = device
         self.save_mlir = save_mlir
         self.save_vmfb = save_vmfb
+        self.increase_stack_alloc_size = increase_stack_alloc_size
 
     def create_and_check_module(self):
         model, input, act_out = get_hf_model("bert-base-uncased")
         shark_args.save_mlir = self.save_mlir
         shark_args.save_vmfb = self.save_vmfb
+        shark_args.increase_stack_alloc_size = self.increase_stack_alloc_size
         shark_module = SharkInference(model, (input,),
                                       device=self.device,
                                       dynamic=self.dynamic,
@@ -51,10 +54,10 @@ class BertModuleTest(unittest.TestCase):
         self.module_tester.device = "cpu"
         self.module_tester.create_and_check_module()
     
-    @pytest.mark.xfail(reason="Language models currently failing for dynamic case")
     def test_module_dynamic_cpu(self):
         self.module_tester.dynamic = True
         self.module_tester.device = "cpu"
+        self.module_tester.increase_stack_alloc_size = True
         self.module_tester.create_and_check_module()
     
     @pytest.mark.skipif(check_device_drivers("gpu"), reason="nvidia-smi not found")

--- a/tank/pytorch/conftest.py
+++ b/tank/pytorch/conftest.py
@@ -2,3 +2,4 @@ def pytest_addoption(parser):
     # Attaches SHARK command-line arguments to the pytest machinery.
     parser.addoption("--save_mlir", action="store_true", default="False", help="Pass option to save input MLIR module to /tmp/ directory.")
     parser.addoption("--save_vmfb", action="store_true", default="False", help="Pass option to save input MLIR module to /tmp/ directory.")
+    parser.addoption("--benchmark", action="store_true", default="False", help="Saves test benchmark results to .csv in working directory.")


### PR DESCRIPTION
Adds a flag to shark parser that increases LLVMCPU stack allocation size limit from 32KB to 128KB.
This fixes issues with running the dynamic case for language models on CPU.