### PR TITLE
Add TempFileSaver pytest option to tank TF tests.

### DIFF
--- a/tank/tf/conftest.py
+++ b/tank/tf/conftest.py
@@ -1,0 +1,3 @@
+def pytest_addoption(parser):
+    # Attaches SHARK command-line arguments to the pytest machinery.
+    parser.addoption("--save_temps", action="store_true", default="False", help="Saves IREE reproduction artifacts for filing upstream issues.")

--- a/tank/tf/hf_masked_lm/albert-base-v2_test.py
+++ b/tank/tf/hf_masked_lm/albert-base-v2_test.py
@@ -3,30 +3,65 @@ from tank.model_utils_tf import compare_tensors_tf
 from shark.iree_utils import check_device_drivers
 from shark.shark_inference import SharkInference
 
+import iree.compiler as ireec
 import unittest
 import pytest
+import numpy as np
+import tempfile
 
 
 class AlbertBaseModuleTester:
+    
+    def __init__(
+        self,
+        save_temps=False
+    ):
+        self.save_temps = save_temps
 
     def create_and_check_module(self, dynamic, device):
         model, input, act_out = get_causal_lm_model("albert-base-v2")
-        shark_module = SharkInference(model, (input,),
-                                      device=device,
-                                      dynamic=dynamic,
-                                      jit_trace=True)
-        shark_module.set_frontend("tensorflow")
-        shark_module.compile()
-        results = shark_module.forward((input))
-        assert True == compare_tensors_tf(act_out, results)
+        save_temps = self.save_temps
+        if save_temps == True:
+            if dynamic == True:
+                repro_dir = f"albert_base_v2_dynamic_{device}"
+            else:
+                repro_dir = f"albert_base_v2_static_{device}"
+            temp_dir = tempfile.mkdtemp(prefix=repro_dir)
+            np.set_printoptions(threshold=np.inf)
+            np.save(f"{temp_dir}/input1.npy", input[0])
+            np.save(f"{temp_dir}/input2.npy", input[1])
+            exp_out = act_out.numpy()
+            with open(f"{temp_dir}/expected_out.txt", "w") as out_file:
+                out_file.write(np.array2string(exp_out))
+            with ireec.tools.TempFileSaver(temp_dir):
+                shark_module = SharkInference(model, (input,),
+                                              device=device,
+                                              dynamic=dynamic,
+                                              jit_trace=True)
+                shark_module.set_frontend("tensorflow")
+                shark_module.compile()
+                results = shark_module.forward((input))
+            assert True == compare_tensors_tf(act_out, results)
+                
+        else:            
+            shark_module = SharkInference(model, (input,),
+                                          device=device,
+                                          dynamic=dynamic,
+                                          jit_trace=True)
+            shark_module.set_frontend("tensorflow")
+            shark_module.compile()
+            results = shark_module.forward((input))
+            assert True == compare_tensors_tf(act_out, results)
 
 
 class AlbertBaseModuleTest(unittest.TestCase):
 
-    def setUp(self):
-        self.module_tester = AlbertBaseModuleTester()
+    @pytest.fixture(autouse=True)
+    def configure(self, pytestconfig):
+        self.module_tester = AlbertBaseModuleTester(self)
+        self.module_tester.save_temps = pytestconfig.getoption("save_temps")
 
-    @pytest.mark.xfail
+    @pytest.mark.xfail(reason="Upstream IREE issue, see https://github.com/google/iree/issues/9536")
     def test_module_static_cpu(self):
         dynamic = False
         device = "cpu"

--- a/tank/tf/hf_masked_lm/bert-base-uncased_test.py
+++ b/tank/tf/hf_masked_lm/bert-base-uncased_test.py
@@ -3,30 +3,65 @@ from tank.model_utils_tf import compare_tensors_tf
 from shark.iree_utils import check_device_drivers
 from shark.shark_inference import SharkInference
 
+import iree.compiler as ireec
 import unittest
 import pytest
+import numpy as np
+import tempfile
 
 
 class BertBaseUncasedModuleTester:
+    
+    def __init__(
+        self,
+        save_temps=False
+    ):
+        self.save_temps = save_temps
 
     def create_and_check_module(self, dynamic, device):
         model, input, act_out = get_causal_lm_model("bert-base-uncased")
-        shark_module = SharkInference(model, (input,),
-                                      device=device,
-                                      dynamic=dynamic,
-                                      jit_trace=True)
-        shark_module.set_frontend("tensorflow")
-        shark_module.compile()
-        results = shark_module.forward((input))
-        assert True == compare_tensors_tf(act_out, results)
+        save_temps = self.save_temps
+        if save_temps == True:
+            if dynamic == True:
+                repro_dir = f"bert_base_uncased_dynamic_{device}"
+            else:
+                repro_dir = f"bert_base_uncased_static_{device}"
+            temp_dir = tempfile.mkdtemp(prefix=repro_dir)
+            np.set_printoptions(threshold=np.inf)
+            np.save(f"{temp_dir}/input1.npy", input[0])
+            np.save(f"{temp_dir}/input2.npy", input[1])
+            exp_out = act_out.numpy()
+            with open(f"{temp_dir}/expected_out.txt", "w") as out_file:
+                out_file.write(np.array2string(exp_out))
+            with ireec.tools.TempFileSaver(temp_dir):
+                shark_module = SharkInference(model, (input,),
+                                              device=device,
+                                              dynamic=dynamic,
+                                              jit_trace=True)
+                shark_module.set_frontend("tensorflow")
+                shark_module.compile()
+                results = shark_module.forward((input))
+            assert True == compare_tensors_tf(act_out, results)
+                
+        else:            
+            shark_module = SharkInference(model, (input,),
+                                          device=device,
+                                          dynamic=dynamic,
+                                          jit_trace=True)
+            shark_module.set_frontend("tensorflow")
+            shark_module.compile()
+            results = shark_module.forward((input))
+            assert True == compare_tensors_tf(act_out, results)
 
 
 class BertBaseUncasedModuleTest(unittest.TestCase):
 
-    def setUp(self):
-        self.module_tester = BertBaseUncasedModuleTester()
+    @pytest.fixture(autouse=True)
+    def configure(self, pytestconfig):
+        self.module_tester = BertBaseUncasedModuleTester(self)
+        self.module_tester.save_temps = pytestconfig.getoption("save_temps")
 
-    @pytest.mark.xfail
+    @pytest.mark.xfail(reason="Upstream IREE issue, see https://github.com/google/iree/issues/9536")
     def test_module_static_cpu(self):
         dynamic = False
         device = "cpu"

--- a/tank/tf/hf_masked_lm/camembert-base_test.py
+++ b/tank/tf/hf_masked_lm/camembert-base_test.py
@@ -3,30 +3,65 @@ from tank.model_utils_tf import compare_tensors_tf
 from shark.iree_utils import check_device_drivers
 from shark.shark_inference import SharkInference
 
+import iree.compiler as ireec
 import unittest
 import pytest
+import numpy as np
+import tempfile
 
 
 class CamemBertModuleTester:
+    
+    def __init__(
+        self,
+        save_temps=False
+    ):
+        self.save_temps = save_temps
 
     def create_and_check_module(self, dynamic, device):
         model, input, act_out = get_causal_lm_model("camembert-base")
-        shark_module = SharkInference(model, (input,),
-                                      device=device,
-                                      dynamic=dynamic,
-                                      jit_trace=True)
-        shark_module.set_frontend("tensorflow")
-        shark_module.compile()
-        results = shark_module.forward((input))
-        assert True == compare_tensors_tf(act_out, results)
+        save_temps = self.save_temps
+        if save_temps == True:
+            if dynamic == True:
+                repro_dir = f"camembert-base_dynamic_{device}"
+            else:
+                repro_dir = f"camembert-base_static_{device}"
+            temp_dir = tempfile.mkdtemp(prefix=repro_dir)
+            np.set_printoptions(threshold=np.inf)
+            np.save(f"{temp_dir}/input1.npy", input[0])
+            np.save(f"{temp_dir}/input2.npy", input[1])
+            exp_out = act_out.numpy()
+            with open(f"{temp_dir}/expected_out.txt", "w") as out_file:
+                out_file.write(np.array2string(exp_out))
+            with ireec.tools.TempFileSaver(temp_dir):
+                shark_module = SharkInference(model, (input,),
+                                              device=device,
+                                              dynamic=dynamic,
+                                              jit_trace=True)
+                shark_module.set_frontend("tensorflow")
+                shark_module.compile()
+                results = shark_module.forward((input))
+            assert True == compare_tensors_tf(act_out, results)
+                
+        else:            
+            shark_module = SharkInference(model, (input,),
+                                          device=device,
+                                          dynamic=dynamic,
+                                          jit_trace=True)
+            shark_module.set_frontend("tensorflow")
+            shark_module.compile()
+            results = shark_module.forward((input))
+            assert True == compare_tensors_tf(act_out, results)
 
 
 class CamemBertModuleTest(unittest.TestCase):
 
-    def setUp(self):
-        self.module_tester = CamemBertModuleTester()
+    @pytest.fixture(autouse=True)
+    def configure(self, pytestconfig):
+        self.module_tester=CamemBertModuleTester(self)
+        self.module_tester.save_temps = pytestconfig.getoption("save_temps")
 
-    @pytest.mark.xfail
+    @pytest.mark.xfail(reason="Upstream IREE issue, see https://github.com/google/iree/issues/9536")
     def test_module_static_cpu(self):
         dynamic = False
         device = "cpu"

--- a/tank/tf/hf_masked_lm/convbert-base-turkish-cased_test.py
+++ b/tank/tf/hf_masked_lm/convbert-base-turkish-cased_test.py
@@ -3,31 +3,66 @@ from tank.model_utils_tf import compare_tensors_tf
 from shark.iree_utils import check_device_drivers
 from shark.shark_inference import SharkInference
 
+import iree.compiler as ireec
 import unittest
 import pytest
+import numpy as np
+import tempfile
 
 
 class ConvBertModuleTester:
+    
+    def __init__(
+        self,
+        save_temps=False
+    ):
+        self.save_temps = save_temps
 
     def create_and_check_module(self, dynamic, device):
         model, input, act_out = get_causal_lm_model(
             "dbmdz/convbert-base-turkish-cased")
-        shark_module = SharkInference(model, (input,),
-                                      device=device,
-                                      dynamic=dynamic,
-                                      jit_trace=True)
-        shark_module.set_frontend("tensorflow")
-        shark_module.compile()
-        results = shark_module.forward((input))
-        assert True == compare_tensors_tf(act_out, results)
+        save_temps = self.save_temps
+        if save_temps == True:
+            if dynamic == True:
+                repro_dir = f"convbert_base_dynamic_{device}"
+            else:
+                repro_dir = f"convbert_base_static_{device}"
+            temp_dir = tempfile.mkdtemp(prefix=repro_dir)
+            np.set_printoptions(threshold=np.inf)
+            np.save(f"{temp_dir}/input1.npy", input[0])
+            np.save(f"{temp_dir}/input2.npy", input[1])
+            exp_out = act_out.numpy()
+            with open(f"{temp_dir}/expected_out.txt", "w") as out_file:
+                out_file.write(np.array2string(exp_out))
+            with ireec.tools.TempFileSaver(temp_dir):
+                shark_module = SharkInference(model, (input,),
+                                              device=device,
+                                              dynamic=dynamic,
+                                              jit_trace=True)
+                shark_module.set_frontend("tensorflow")
+                shark_module.compile()
+                results = shark_module.forward((input))
+            assert True == compare_tensors_tf(act_out, results)
+                
+        else:            
+            shark_module = SharkInference(model, (input,),
+                                          device=device,
+                                          dynamic=dynamic,
+                                          jit_trace=True)
+            shark_module.set_frontend("tensorflow")
+            shark_module.compile()
+            results = shark_module.forward((input))
+            assert True == compare_tensors_tf(act_out, results)
 
 
 class ConvBertModuleTest(unittest.TestCase):
 
-    def setUp(self):
-        self.module_tester = ConvBertModuleTester()
+    @pytest.fixture(autouse=True)
+    def configure(self, pytestconfig):
+        self.module_tester = ConvBertModuleTester(self)
+        self.module_tester.save_temps = pytestconfig.getoption("save_temps")
 
-    @pytest.mark.xfail
+    @pytest.mark.xfail(reason="Upstream IREE issue, see https://github.com/google/iree/issues/9536")
     def test_module_static_cpu(self):
         dynamic = False
         device = "cpu"

--- a/tank/tf/hf_masked_lm/deberta-base_test.py
+++ b/tank/tf/hf_masked_lm/deberta-base_test.py
@@ -3,28 +3,63 @@ from tank.model_utils_tf import compare_tensors_tf
 from shark.iree_utils import check_device_drivers
 from shark.shark_inference import SharkInference
 
+import iree.compiler as ireec
 import unittest
 import pytest
+import numpy as np
+import tempfile
 
 
 class DebertaModuleTester:
+    
+    def __init__(
+        self,
+        save_temps=False
+    ):
+        self.save_temps = save_temps
 
     def create_and_check_module(self, dynamic, device):
         model, input, act_out = get_causal_lm_model("microsoft/deberta-base")
-        shark_module = SharkInference(model, (input,),
-                                      device=device,
-                                      dynamic=dynamic,
-                                      jit_trace=True)
-        shark_module.set_frontend("tensorflow")
-        shark_module.compile()
-        results = shark_module.forward((input))
-        assert True == compare_tensors_tf(act_out, results)
+        save_temps = self.save_temps
+        if save_temps == True:
+            if dynamic == True:
+                repro_dir = f"deberta-base_dynamic_{device}"
+            else:
+                repro_dir = f"deberta-base_static_{device}"
+            temp_dir = tempfile.mkdtemp(prefix=repro_dir)
+            np.set_printoptions(threshold=np.inf)
+            np.save(f"{temp_dir}/input1.npy", input[0])
+            np.save(f"{temp_dir}/input2.npy", input[1])
+            exp_out = act_out.numpy()
+            with open(f"{temp_dir}/expected_out.txt", "w") as out_file:
+                out_file.write(np.array2string(exp_out))
+            with ireec.tools.TempFileSaver(temp_dir):
+                shark_module = SharkInference(model, (input,),
+                                              device=device,
+                                              dynamic=dynamic,
+                                              jit_trace=True)
+                shark_module.set_frontend("tensorflow")
+                shark_module.compile()
+                results = shark_module.forward((input))
+            assert True == compare_tensors_tf(act_out, results)
+                
+        else:            
+            shark_module = SharkInference(model, (input,),
+                                          device=device,
+                                          dynamic=dynamic,
+                                          jit_trace=True)
+            shark_module.set_frontend("tensorflow")
+            shark_module.compile()
+            results = shark_module.forward((input))
+            assert True == compare_tensors_tf(act_out, results)
 
 
 class DebertaModuleTest(unittest.TestCase):
-
-    def setUp(self):
-        self.module_tester = DebertaModuleTester()
+    
+    @pytest.fixture(autouse=True)
+    def configure(self, pytestconfig):
+        self.module_tester = DebertaModuleTester(self)
+        self.module_tester.save_temps = pytestconfig.getoption("save_temps")
 
     @pytest.mark.xfail
     @pytest.mark.skip(reason="deberta currently failing in the lowering passes."

--- a/tank/tf/hf_masked_lm/distilbert-base-uncased_test.py
+++ b/tank/tf/hf_masked_lm/distilbert-base-uncased_test.py
@@ -3,30 +3,64 @@ from tank.model_utils_tf import compare_tensors_tf
 from shark.iree_utils import check_device_drivers
 from shark.shark_inference import SharkInference
 
+import iree.compiler as ireec
 import unittest
 import pytest
+import numpy as np
+import tempfile
 
 
 class DistilBertModuleTester:
+    
+    def __init__(
+        self,
+        save_temps=False
+    ):
+        self.save_temps = save_temps
 
     def create_and_check_module(self, dynamic, device):
         model, input, act_out = get_causal_lm_model("distilbert-base-uncased")
-        shark_module = SharkInference(model, (input,),
-                                      device=device,
-                                      dynamic=dynamic,
-                                      jit_trace=True)
-        shark_module.set_frontend("tensorflow")
-        shark_module.compile()
-        results = shark_module.forward((input))
-        assert True == compare_tensors_tf(act_out, results)
-
+        save_temps = self.save_temps
+        if save_temps == True:
+            if dynamic == True:
+                repro_dir = f"distilbert_dynamic_{device}"
+            else:
+                repro_dir = f"distilbert__static_{device}"
+            temp_dir = tempfile.mkdtemp(prefix=repro_dir)
+            np.set_printoptions(threshold=np.inf)
+            np.save(f"{temp_dir}/input1.npy", input[0])
+            np.save(f"{temp_dir}/input2.npy", input[1])
+            exp_out = act_out.numpy()
+            with open(f"{temp_dir}/expected_out.txt", "w") as out_file:
+                out_file.write(np.array2string(exp_out))
+            with ireec.tools.TempFileSaver(temp_dir):
+                shark_module = SharkInference(model, (input,),
+                                              device=device,
+                                              dynamic=dynamic,
+                                              jit_trace=True)
+                shark_module.set_frontend("tensorflow")
+                shark_module.compile()
+                results = shark_module.forward((input))
+            assert True == compare_tensors_tf(act_out, results)
+                
+        else:            
+            shark_module = SharkInference(model, (input,),
+                                          device=device,
+                                          dynamic=dynamic,
+                                          jit_trace=True)
+            shark_module.set_frontend("tensorflow")
+            shark_module.compile()
+            results = shark_module.forward((input))
+            assert True == compare_tensors_tf(act_out, results)
 
 class DistilBertModuleTest(unittest.TestCase):
 
-    def setUp(self):
-        self.module_tester = DistilBertModuleTester()
+    @pytest.fixture(autouse=True)
+    def configure(self, pytestconfig):
+        self.module_tester = DistilBertModuleTester(self)
+        self.module_tester.save_temps = pytestconfig.getoption("save_temps")
 
-    @pytest.mark.xfail
+    @pytest.mark.xfail(reason="Upstream IREE issue, see https://github.com/google/iree/issues/9536")
     def test_module_static_cpu(self):
         dynamic = False
         device = "cpu"

--- a/tank/tf/hf_masked_lm/electra-small-discriminator_test.py
+++ b/tank/tf/hf_masked_lm/electra-small-discriminator_test.py
@@ -3,31 +3,65 @@ from tank.model_utils_tf import compare_tensors_tf
 from shark.iree_utils import check_device_drivers
 from shark.shark_inference import SharkInference
 
+import iree.compiler as ireec
 import unittest
 import pytest
+import numpy as np
+import tempfile
 
 
 class ElectraModuleTester:
+    
+    def __init__(
+        self,
+        save_temps=False
+    ):
+        self.save_temps = save_temps
 
     def create_and_check_module(self, dynamic, device):
-        model, input, act_out = get_causal_lm_model(
-            "google/electra-small-discriminator")
-        shark_module = SharkInference(model, (input,),
-                                      device=device,
-                                      dynamic=dynamic,
-                                      jit_trace=True)
-        shark_module.set_frontend("tensorflow")
-        shark_module.compile()
-        results = shark_module.forward((input))
-        assert True == compare_tensors_tf(act_out, results)
+        model, input, act_out = get_causal_lm_model("google/electra-small-discriminator")
+        save_temps = self.save_temps
+        if save_temps == True:
+            if dynamic == True:
+                repro_dir = f"electra_dynamic_{device}"
+            else:
+                repro_dir = f"electra__static_{device}"
+            temp_dir = tempfile.mkdtemp(prefix=repro_dir)
+            np.set_printoptions(threshold=np.inf)
+            np.save(f"{temp_dir}/input1.npy", input[0])
+            np.save(f"{temp_dir}/input2.npy", input[1])
+            exp_out = act_out.numpy()
+            with open(f"{temp_dir}/expected_out.txt", "w") as out_file:
+                out_file.write(np.array2string(exp_out)) 
+            with ireec.tools.TempFileSaver(temp_dir):
+                shark_module = SharkInference(model, (input,),
+                                              device=device,
+                                              dynamic=dynamic,
+                                              jit_trace=True)
+                shark_module.set_frontend("tensorflow")
+                shark_module.compile()
+                results = shark_module.forward((input))
+            assert True == compare_tensors_tf(act_out, results)
+                
+        else:            
+            shark_module = SharkInference(model, (input,),
+                                          device=device,
+                                          dynamic=dynamic,
+                                          jit_trace=True)
+            shark_module.set_frontend("tensorflow")
+            shark_module.compile()
+            results = shark_module.forward((input))
+            assert True == compare_tensors_tf(act_out, results)
 
 
 class ElectraModuleTest(unittest.TestCase):
 
-    def setUp(self):
-        self.module_tester = ElectraModuleTester()
+    @pytest.fixture(autouse=True)
+    def configure(self):
+        self.module_tester = ElectraModuleTester(self)
+        self.module_tester.save_temps = pytestconfig.getoption("save_temps")
 
-    @pytest.mark.xfail
+    @pytest.mark.xfail(reason="Upstream IREE issue, see https://github.com/google/iree/issues/9536")
     def test_module_static_cpu(self):
         dynamic = False
         device = "cpu"

--- a/tank/tf/hf_masked_lm/funnel-transformer_test.py
+++ b/tank/tf/hf_masked_lm/funnel-transformer_test.py
@@ -3,28 +3,63 @@ from tank.model_utils_tf import compare_tensors_tf
 from shark.iree_utils import check_device_drivers
 from shark.shark_inference import SharkInference
 
+import iree.compiler as ireec
 import unittest
 import pytest
+import numpy as np
+import tempfile
 
 
 class FunnelModuleTester:
+    
+    def __init__(
+        self,
+        save_temps=False
+    ):
+        self.save_temps = save_temps
 
     def create_and_check_module(self, dynamic, device):
         model, input, act_out = get_causal_lm_model("funnel-transformer/small")
-        shark_module = SharkInference(model, (input,),
-                                      device=device,
-                                      dynamic=dynamic,
-                                      jit_trace=True)
-        shark_module.set_frontend("tensorflow")
-        shark_module.compile()
-        results = shark_module.forward((input))
-        assert True == compare_tensors_tf(act_out, results)
+        save_temps = self.save_temps
+        if save_temps == True:
+            if dynamic == True:
+                repro_dir = f"funnel_dynamic_{device}"
+            else:
+                repro_dir = f"funnel__static_{device}"
+            temp_dir = tempfile.mkdtemp(prefix=repro_dir)
+            np.set_printoptions(threshold=np.inf)
+            np.save(f"{temp_dir}/input1.npy", input[0])
+            np.save(f"{temp_dir}/input2.npy", input[1])
+            exp_out = act_out.numpy()
+            with open(f"{temp_dir}/expected_out.txt", "w") as out_file:
+                out_file.write(np.array2string(exp_out))
+            with ireec.tools.TempFileSaver(temp_dir):
+                shark_module = SharkInference(model, (input,),
+                                              device=device,
+                                              dynamic=dynamic,
+                                              jit_trace=True)
+                shark_module.set_frontend("tensorflow")
+                shark_module.compile()
+                results = shark_module.forward((input))
+            assert True == compare_tensors_tf(act_out, results)
+                
+        else:            
+            shark_module = SharkInference(model, (input,),
+                                          device=device,
+                                          dynamic=dynamic,
+                                          jit_trace=True)
+            shark_module.set_frontend("tensorflow")
+            shark_module.compile()
+            results = shark_module.forward((input))
+            assert True == compare_tensors_tf(act_out, results)
 
 
 class FunnelModuleTest(unittest.TestCase):
 
-    def setUp(self):
-        self.module_tester = FunnelModuleTester()
+    @pytest.fixture(autouse=True)
+    def configure(self, pytestconfig):
+        self.module_tester = FunnelModuleTester(self)
+        self.module_tester.save_temps = pytestconfig.getoption("save_temps")
 
     @pytest.mark.skip(reason="funnel currently failing in the lowering passes.")
     def test_module_static_cpu(self):

--- a/tank/tf/hf_masked_lm/layoutlm-base-uncased_test.py
+++ b/tank/tf/hf_masked_lm/layoutlm-base-uncased_test.py
@@ -3,31 +3,66 @@ from tank.model_utils_tf import compare_tensors_tf
 from shark.iree_utils import check_device_drivers
 from shark.shark_inference import SharkInference
 
+import iree.compiler as ireec
 import unittest
 import pytest
+import numpy as np
+import tempfile
 
 
 class LayoutLmModuleTester:
+    
+    def __init__(
+        self,
+        save_temps=False
+    ):
+        self.save_temps = save_temps
 
     def create_and_check_module(self, dynamic, device):
         model, input, act_out = get_causal_lm_model(
             "microsoft/layoutlm-base-uncased")
-        shark_module = SharkInference(model, (input,),
-                                      device=device,
-                                      dynamic=dynamic,
-                                      jit_trace=True)
-        shark_module.set_frontend("tensorflow")
-        shark_module.compile()
-        results = shark_module.forward((input))
-        assert True == compare_tensors_tf(act_out, results)
+        save_temps = self.save_temps
+        if save_temps == True:
+            if dynamic == True:
+                repro_dir = f"layoutlm_dynamic_{device}"
+            else:
+                repro_dir = f"layoutlm__static_{device}"
+            temp_dir = tempfile.mkdtemp(prefix=repro_dir)
+            np.set_printoptions(threshold=np.inf)
+            np.save(f"{temp_dir}/input1.npy", input[0])
+            np.save(f"{temp_dir}/input2.npy", input[1])
+            exp_out = act_out.numpy()
+            with open(f"{temp_dir}/expected_out.txt", "w") as out_file:
+                out_file.write(np.array2string(exp_out))
+            with ireec.tools.TempFileSaver(temp_dir):
+                shark_module = SharkInference(model, (input,),
+                                              device=device,
+                                              dynamic=dynamic,
+                                              jit_trace=True)
+                shark_module.set_frontend("tensorflow")
+                shark_module.compile()
+                results = shark_module.forward((input))
+            assert True == compare_tensors_tf(act_out, results)
+                
+        else:            
+            shark_module = SharkInference(model, (input,),
+                                          device=device,
+                                          dynamic=dynamic,
+                                          jit_trace=True)
+            shark_module.set_frontend("tensorflow")
+            shark_module.compile()
+            results = shark_module.forward((input))
+            assert True == compare_tensors_tf(act_out, results)
 
 
 class LayoutLmModuleTest(unittest.TestCase):
 
-    def setUp(self):
-        self.module_tester = LayoutLmModuleTester()
+    @pytest.fixture(autouse=True)
+    def configure(self, pytestconfig):
+        self.module_tester = LayoutLmModuleTester(self)
+        self.module_tester.save_temps = pytestconfig.getoption("save_temps")
     
-    @pytest.mark.xfail
+    @pytest.mark.xfail(reason="Upstream IREE issue, see https://github.com/google/iree/issues/9536")
     def test_module_static_cpu(self):
         dynamic = False
         device = "cpu"

--- a/tank/tf/hf_masked_lm/longformer-base-4096_test.py
+++ b/tank/tf/hf_masked_lm/longformer-base-4096_test.py
@@ -3,29 +3,63 @@ from tank.model_utils_tf import compare_tensors_tf
 from shark.iree_utils import check_device_drivers
 from shark.shark_inference import SharkInference
 
+import iree.compiler as ireec
 import unittest
 import pytest
+import numpy as np
+import tempfile
 
 
 class LongFormerModuleTester:
+    
+    def __init__(
+        self,
+        save_temps=False
+    ):
+        self.save_temps = save_temps
 
     def create_and_check_module(self, dynamic, device):
-        model, input, act_out = get_causal_lm_model(
-            "allenai/longformer-base-4096")
-        shark_module = SharkInference(model, (input,),
-                                      device=device,
-                                      dynamic=dynamic,
-                                      jit_trace=True)
-        shark_module.set_frontend("tensorflow")
-        shark_module.compile()
-        results = shark_module.forward((input))
-        assert True == compare_tensors_tf(act_out, results)
+        model, input, act_out = get_causal_lm_model("allenai/longformer-base-4096")
+        save_temps = self.save_temps
+        if save_temps == True:
+            if dynamic == True:
+                repro_dir = f"longformer_dynamic_{device}"
+            else:
+                repro_dir = f"longformer__static_{device}"
+            temp_dir = tempfile.mkdtemp(prefix=repro_dir)
+            np.set_printoptions(threshold=np.inf)
+            np.save(f"{temp_dir}/input1.npy", input[0])
+            np.save(f"{temp_dir}/input2.npy", input[1])
+            exp_out = act_out.numpy()
+            with open(f"{temp_dir}/expected_out.txt", "w") as out_file:
+                out_file.write(np.array2string(exp_out))
+            with ireec.tools.TempFileSaver(temp_dir):
+                shark_module = SharkInference(model, (input,),
+                                              device=device,
+                                              dynamic=dynamic,
+                                              jit_trace=True)
+                shark_module.set_frontend("tensorflow")
+                shark_module.compile()
+                results = shark_module.forward((input))
+            assert True == compare_tensors_tf(act_out, results)
+                
+        else:            
+            shark_module = SharkInference(model, (input,),
+                                          device=device,
+                                          dynamic=dynamic,
+                                          jit_trace=True)
+            shark_module.set_frontend("tensorflow")
+            shark_module.compile()
+            results = shark_module.forward((input))
+            assert True == compare_tensors_tf(act_out, results)
 
 
 class LongFormerModuleTest(unittest.TestCase):
 
-    def setUp(self):
-        self.module_tester = LongFormerModuleTester()
+    @pytest.fixture(autouse=True)
+    def configure(self, pytestconfig):
+        self.module_tester = LongFormerModuleTester(self)
+        self.module_tester.save_temps = pytestconfig.getoption("save_temps")
 
     @pytest.mark.skip(
         reason="longformer currently failing in the lowering passes.")

--- a/tank/tf/hf_masked_lm/mobilebert-uncased_test.py
+++ b/tank/tf/hf_masked_lm/mobilebert-uncased_test.py
@@ -3,30 +3,65 @@ from tank.model_utils_tf import compare_tensors_tf
 from shark.iree_utils import check_device_drivers
 from shark.shark_inference import SharkInference
 
+import iree.compiler as ireec
 import unittest
 import pytest
+import numpy as np
+import tempfile
 
 
 class MobileBertModuleTester:
+    
+    def __init__(
+        self,
+        save_temps=False
+    ):
+        self.save_temps = save_temps
 
     def create_and_check_module(self, dynamic, device):
         model, input, act_out = get_causal_lm_model("google/mobilebert-uncased")
-        shark_module = SharkInference(model, (input,),
-                                      device=device,
-                                      dynamic=dynamic,
-                                      jit_trace=True)
-        shark_module.set_frontend("tensorflow")
-        shark_module.compile()
-        results = shark_module.forward((input))
-        assert True == compare_tensors_tf(act_out, results)
+        save_temps = self.save_temps
+        if save_temps == True:
+            if dynamic == True:
+                repro_dir = f"mobilebert_dynamic_{device}"
+            else:
+                repro_dir = f"mobilebert__static_{device}"
+            temp_dir = tempfile.mkdtemp(prefix=repro_dir)
+            np.set_printoptions(threshold=np.inf)
+            np.save(f"{temp_dir}/input1.npy", input[0])
+            np.save(f"{temp_dir}/input2.npy", input[1])
+            exp_out = act_out.numpy()
+            with open(f"{temp_dir}/expected_out.txt", "w") as out_file:
+                out_file.write(np.array2string(exp_out))
+            with ireec.tools.TempFileSaver(temp_dir):
+                shark_module = SharkInference(model, (input,),
+                                              device=device,
+                                              dynamic=dynamic,
+                                              jit_trace=True)
+                shark_module.set_frontend("tensorflow")
+                shark_module.compile()
+                results = shark_module.forward((input))
+            assert True == compare_tensors_tf(act_out, results)
+                
+        else:            
+            shark_module = SharkInference(model, (input,),
+                                          device=device,
+                                          dynamic=dynamic,
+                                          jit_trace=True)
+            shark_module.set_frontend("tensorflow")
+            shark_module.compile()
+            results = shark_module.forward((input))
+            assert True == compare_tensors_tf(act_out, results)
 
 
 class MobileBertModuleTest(unittest.TestCase):
 
-    def setUp(self):
-        self.module_tester = MobileBertModuleTester()
+    @pytest.fixture(autouse=True)
+    def configure(self, pytestconfig):
+        self.module_tester = MobileBertModuleTester(self)
+        self.module_tester.save_temps = pytestconfig.getoption("save_temps")
 
-    @pytest.mark.xfail
+    @pytest.mark.xfail(reason="Upstream IREE issue, see https://github.com/google/iree/issues/9536")
     def test_module_static_cpu(self):
         dynamic = False
         device = "cpu"

--- a/tank/tf/hf_masked_lm/mpnet-base_test.py
+++ b/tank/tf/hf_masked_lm/mpnet-base_test.py
@@ -3,30 +3,65 @@ from tank.model_utils_tf import compare_tensors_tf
 from shark.iree_utils import check_device_drivers
 from shark.shark_inference import SharkInference
 
+import iree.compiler as ireec
 import unittest
 import pytest
+import numpy as np
+import tempfile
 
 
 class MpNetModuleTester:
+    
+    def __init__(
+        self,
+        save_temps=False
+    ):
+        self.save_temps = save_temps
 
     def create_and_check_module(self, dynamic, device):
         model, input, act_out = get_causal_lm_model("microsoft/mpnet-base")
-        shark_module = SharkInference(model, (input,),
-                                      device=device,
-                                      dynamic=dynamic,
-                                      jit_trace=True)
-        shark_module.set_frontend("tensorflow")
-        shark_module.compile()
-        results = shark_module.forward((input))
-        assert True == compare_tensors_tf(act_out, results)
+        save_temps = self.save_temps
+        if save_temps == True:
+            if dynamic == True:
+                repro_dir = f"mpnet_dynamic_{device}"
+            else:
+                repro_dir = f"mpnet__static_{device}"
+            temp_dir = tempfile.mkdtemp(prefix=repro_dir)
+            np.set_printoptions(threshold=np.inf)
+            np.save(f"{temp_dir}/input1.npy", input[0])
+            np.save(f"{temp_dir}/input2.npy", input[1])
+            exp_out = act_out.numpy()
+            with open(f"{temp_dir}/expected_out.txt", "w") as out_file:
+                out_file.write(np.array2string(exp_out))
+            with ireec.tools.TempFileSaver(temp_dir):
+                shark_module = SharkInference(model, (input,),
+                                              device=device,
+                                              dynamic=dynamic,
+                                              jit_trace=True)
+                shark_module.set_frontend("tensorflow")
+                shark_module.compile()
+                results = shark_module.forward((input))
+            assert True == compare_tensors_tf(act_out, results)
+                
+        else:            
+            shark_module = SharkInference(model, (input,),
+                                          device=device,
+                                          dynamic=dynamic,
+                                          jit_trace=True)
+            shark_module.set_frontend("tensorflow")
+            shark_module.compile()
+            results = shark_module.forward((input))
+            assert True == compare_tensors_tf(act_out, results)
 
 
 class MpNetModuleTest(unittest.TestCase):
+    
+    @pytest.fixture(autouse=True)
+    def configure(self, pytestconfig):
+        self.module_tester = MpNetModuleTester(self)
+        self.module_tester.save_temps = pytestconfig.getoption("save_temps")
 
-    def setUp(self):
-        self.module_tester = MpNetModuleTester()
-
-    @pytest.mark.xfail
+    @pytest.mark.xfail(reason="Upstream IREE issue, see https://github.com/google/iree/issues/9536")
     def test_module_static_cpu(self):
         dynamic = False
         device = "cpu"

--- a/tank/tf/hf_masked_lm/rembert_test.py
+++ b/tank/tf/hf_masked_lm/rembert_test.py
@@ -3,28 +3,63 @@ from tank.model_utils_tf import compare_tensors_tf
 from shark.iree_utils import check_device_drivers
 from shark.shark_inference import SharkInference
 
+import iree.compiler as ireec
 import unittest
 import pytest
+import numpy as np
+import tempfile
 
 
 class RemBertModuleTester:
+    
+    def __init__(
+        self,
+        save_temps=False
+    ):
+        self.save_temps = save_temps
 
     def create_and_check_module(self, dynamic, device):
         model, input, act_out = get_causal_lm_model("google/rembert")
-        shark_module = SharkInference(model, (input,),
-                                      device=device,
-                                      dynamic=dynamic,
-                                      jit_trace=True)
-        shark_module.set_frontend("tensorflow")
-        shark_module.compile()
-        results = shark_module.forward((input))
-        assert True == compare_tensors_tf(act_out, results)
+        save_temps = self.save_temps
+        if save_temps == True:
+            if dynamic == True:
+                repro_dir = f"rembert_dynamic_{device}"
+            else:
+                repro_dir = f"rembert__static_{device}"
+            temp_dir = tempfile.mkdtemp(prefix=repro_dir)
+            np.set_printoptions(threshold=np.inf)
+            np.save(f"{temp_dir}/input1.npy", input[0])
+            np.save(f"{temp_dir}/input2.npy", input[1])
+            exp_out = act_out.numpy()
+            with open(f"{temp_dir}/expected_out.txt", "w") as out_file:
+                out_file.write(np.array2string(exp_out))
+            with ireec.tools.TempFileSaver(temp_dir):
+                shark_module = SharkInference(model, (input,),
+                                              device=device,
+                                              dynamic=dynamic,
+                                              jit_trace=True)
+                shark_module.set_frontend("tensorflow")
+                shark_module.compile()
+                results = shark_module.forward((input))
+            assert True == compare_tensors_tf(act_out, results)
+                
+        else:            
+            shark_module = SharkInference(model, (input,),
+                                          device=device,
+                                          dynamic=dynamic,
+                                          jit_trace=True)
+            shark_module.set_frontend("tensorflow")
+            shark_module.compile()
+            results = shark_module.forward((input))
+            assert True == compare_tensors_tf(act_out, results)
 
 
 class RemBertModuleTest(unittest.TestCase):
 
-    def setUp(self):
-        self.module_tester = RemBertModuleTester()
+    @pytest.fixture(autouse=True)
+    def configure(self, pytestconfig):
+        self.module_tester = RemBertModuleTester(self)
+        self.module_tester.save_temps = pytestconfig.getoption("save_temps")
 
     @pytest.mark.skip(reason="rembert currently failing in the lowering passes."
                      )

--- a/tank/tf/hf_masked_lm/roberta-base_test.py
+++ b/tank/tf/hf_masked_lm/roberta-base_test.py
@@ -3,30 +3,65 @@ from tank.model_utils_tf import compare_tensors_tf
 from shark.iree_utils import check_device_drivers
 from shark.shark_inference import SharkInference
 
+import iree.compiler as ireec
 import unittest
 import pytest
+import numpy as np
+import tempfile
 
 
 class RobertaModuleTester:
+    
+    def __init__(
+        self,
+        save_temps=False
+    ):
+        self.save_temps = save_temps
 
     def create_and_check_module(self, dynamic, device):
         model, input, act_out = get_causal_lm_model("roberta-base")
-        shark_module = SharkInference(model, (input,),
-                                      device=device,
-                                      dynamic=dynamic,
-                                      jit_trace=True)
-        shark_module.set_frontend("tensorflow")
-        shark_module.compile()
-        results = shark_module.forward((input))
-        assert True == compare_tensors_tf(act_out, results)
+        save_temps = self.save_temps
+        if save_temps == True:
+            if dynamic == True:
+                repro_dir = f"roberta_dynamic_{device}"
+            else:
+                repro_dir = f"roberta__static_{device}"
+            temp_dir = tempfile.mkdtemp(prefix=repro_dir)
+            np.set_printoptions(threshold=np.inf)
+            np.save(f"{temp_dir}/input1.npy", input[0])
+            np.save(f"{temp_dir}/input2.npy", input[1])
+            exp_out = act_out.numpy()
+            with open(f"{temp_dir}/expected_out.txt", "w") as out_file:
+                out_file.write(np.array2string(exp_out))
+            with ireec.tools.TempFileSaver(temp_dir):
+                shark_module = SharkInference(model, (input,),
+                                              device=device,
+                                              dynamic=dynamic,
+                                              jit_trace=True)
+                shark_module.set_frontend("tensorflow")
+                shark_module.compile()
+                results = shark_module.forward((input))
+            assert True == compare_tensors_tf(act_out, results)
+                
+        else:            
+            shark_module = SharkInference(model, (input,),
+                                          device=device,
+                                          dynamic=dynamic,
+                                          jit_trace=True)
+            shark_module.set_frontend("tensorflow")
+            shark_module.compile()
+            results = shark_module.forward((input))
+            assert True == compare_tensors_tf(act_out, results)
 
 
 class RobertaModuleTest(unittest.TestCase):
 
-    def setUp(self):
-        self.module_tester = RobertaModuleTester()
+    @pytest.fixture(autouse=True)
+    def configure(self, pytestconfig):
+        self.module_tester = RobertaModuleTester(self)
+        self.module_tester.save_temps = pytestconfig.getoption("save_temps")
 
-    @pytest.mark.xfail
+    @pytest.mark.xfail(reason="Upstream IREE issue, see https://github.com/google/iree/issues/9536")
     def test_module_static_cpu(self):
         dynamic = False
         device = "cpu"

--- a/tank/tf/hf_masked_lm/tapas-base_test.py
+++ b/tank/tf/hf_masked_lm/tapas-base_test.py
@@ -3,28 +3,63 @@ from tank.model_utils_tf import compare_tensors_tf
 from shark.iree_utils import check_device_drivers
 from shark.shark_inference import SharkInference
 
+import iree.compiler as ireec
 import unittest
 import pytest
+import numpy as np
+import tempfile
 
 
 class TapasBaseModuleTester:
+    
+    def __init__(
+        self,
+        save_temps=False
+    ):
+        self.save_temps = save_temps
 
     def create_and_check_module(self, dynamic, device):
         model, input, act_out = get_causal_lm_model("google/tapas-base")
-        shark_module = SharkInference(model, (input,),
-                                      device=device,
-                                      dynamic=dynamic,
-                                      jit_trace=True)
-        shark_module.set_frontend("tensorflow")
-        shark_module.compile()
-        results = shark_module.forward((input))
-        assert True == compare_tensors_tf(act_out, results)
+        save_temps = self.save_temps
+        if save_temps == True:
+            if dynamic == True:
+                repro_dir = f"tapas-base_dynamic_{device}"
+            else:
+                repro_dir = f"tapas-base__static_{device}"
+            temp_dir = tempfile.mkdtemp(prefix=repro_dir)
+            np.set_printoptions(threshold=np.inf)
+            np.save(f"{temp_dir}/input1.npy", input[0])
+            np.save(f"{temp_dir}/input2.npy", input[1])
+            exp_out = act_out.numpy()
+            with open(f"{temp_dir}/expected_out.txt", "w") as out_file:
+                out_file.write(np.array2string(exp_out))
+            with ireec.tools.TempFileSaver(temp_dir):
+                shark_module = SharkInference(model, (input,),
+                                              device=device,
+                                              dynamic=dynamic,
+                                              jit_trace=True)
+                shark_module.set_frontend("tensorflow")
+                shark_module.compile()
+                results = shark_module.forward((input))
+            assert True == compare_tensors_tf(act_out, results)
+                
+        else:            
+            shark_module = SharkInference(model, (input,),
+                                          device=device,
+                                          dynamic=dynamic,
+                                          jit_trace=True)
+            shark_module.set_frontend("tensorflow")
+            shark_module.compile()
+            results = shark_module.forward((input))
+            assert True == compare_tensors_tf(act_out, results)
 
 
 class TapasBaseModuleTest(unittest.TestCase):
 
-    def setUp(self):
-        self.module_tester = TapasBaseModuleTester()
+    @pytest.fixture(autouse=True)
+    def configure(self, pytestconfig):
+        self.module_tester = TapasBaseModuleTester(self)
+        self.module_tester.save_temps = pytestconfig.getoption("save_temps")
 
     @pytest.mark.skip(reason="tapas currently failing in the lowering passes.")
     def test_module_static_cpu(self):

--- a/tank/tf/hf_masked_lm/tiny-random-flaubert_test.py
+++ b/tank/tf/hf_masked_lm/tiny-random-flaubert_test.py
@@ -3,31 +3,64 @@ from tank.model_utils_tf import compare_tensors_tf
 from shark.iree_utils import check_device_drivers
 from shark.shark_inference import SharkInference
 
+import iree.compiler as ireec
 import unittest
 import pytest
+import numpy as np
+import tempfile
 
 
 class FlauBertModuleTester:
+    
+    def __init__(
+        self,
+        save_temps=False
+    ):
+        self.save_temps = save_temps
 
     def create_and_check_module(self, dynamic, device):
-        model, input, act_out = get_causal_lm_model(
-            "hf-internal-testing/tiny-random-flaubert")
-        shark_module = SharkInference(model, (input,),
-                                      device=device,
-                                      dynamic=dynamic,
-                                      jit_trace=True)
-        shark_module.set_frontend("tensorflow")
-        shark_module.compile()
-        results = shark_module.forward((input))
-        assert True == compare_tensors_tf(act_out, results)
+        model, input, act_out = get_causal_lm_model("hf-internal-testing/tiny-random-flaubert")
+        save_temps = self.save_temps
+        if save_temps == True:
+            if dynamic == True:
+                repro_dir = f"flaubert_dynamic_{device}"
+            else:
+                repro_dir = f"flaubert__static_{device}"
+            temp_dir = tempfile.mkdtemp(prefix=repro_dir)
+            np.set_printoptions(threshold=np.inf)
+            np.save(f"{temp_dir}/input1.npy", input[0])
+            np.save(f"{temp_dir}/input2.npy", input[1])
+            exp_out = act_out.numpy()
+            with open(f"{temp_dir}/expected_out.txt", "w") as out_file:
+                out_file.write(np.array2string(exp_out))
+            with ireec.tools.TempFileSaver(temp_dir):
+                shark_module = SharkInference(model, (input,),
+                                              device=device,
+                                              dynamic=dynamic,
+                                              jit_trace=True)
+                shark_module.set_frontend("tensorflow")
+                shark_module.compile()
+                results = shark_module.forward((input))
+            assert True == compare_tensors_tf(act_out, results)
+                
+        else:            
+            shark_module = SharkInference(model, (input,),
+                                          device=device,
+                                          dynamic=dynamic,
+                                          jit_trace=True)
+            shark_module.set_frontend("tensorflow")
+            shark_module.compile()
+            results = shark_module.forward((input))
+            assert True == compare_tensors_tf(act_out, results)
 
 
 class FlauBertModuleTest(unittest.TestCase):
 
-    def setUp(self):
-        self.module_tester = FlauBertModuleTester()
+    @pytest.fixture(autouse=True)
+    def configure(self, pytestconfig):
+        self.module_tester = FlauBertModuleTester(self)
+        self.module_tester.save_temps = pytestconfig.getoption("save_temps")
 
-    @pytest.mark.xfail
     def test_module_static_cpu(self):
         dynamic = False
         device = "cpu"

--- a/tank/tf/hf_masked_lm/xlm-roberta-base_test.py
+++ b/tank/tf/hf_masked_lm/xlm-roberta-base_test.py
@@ -3,30 +3,65 @@ from tank.model_utils_tf import compare_tensors_tf
 from shark.iree_utils import check_device_drivers
 from shark.shark_inference import SharkInference
 
+import iree.compiler as ireec
 import unittest
 import pytest
+import numpy as np
+import tempfile
 
 
 class XLMRobertaModuleTester:
+    
+    def __init__(
+        self,
+        save_temps=False
+    ):
+        self.save_temps = save_temps
 
     def create_and_check_module(self, dynamic, device):
         model, input, act_out = get_causal_lm_model("xlm-roberta-base")
-        shark_module = SharkInference(model, (input,),
-                                      device=device,
-                                      dynamic=dynamic,
-                                      jit_trace=True)
-        shark_module.set_frontend("tensorflow")
-        shark_module.compile()
-        results = shark_module.forward((input))
-        assert True == compare_tensors_tf(act_out, results)
+        save_temps = self.save_temps
+        if save_temps == True:
+            if dynamic == True:
+                repro_dir = f"xlm_roberta_dynamic_{device}"
+            else:
+                repro_dir = f"xlm_roberta_static_{device}"
+            temp_dir = tempfile.mkdtemp(prefix=repro_dir)
+            np.set_printoptions(threshold=np.inf)
+            np.save(f"{temp_dir}/input1.npy", input[0])
+            np.save(f"{temp_dir}/input2.npy", input[1])
+            exp_out = act_out.numpy()
+            with open(f"{temp_dir}/expected_out.txt", "w") as out_file:
+                out_file.write(np.array2string(exp_out))
+            with ireec.tools.TempFileSaver(temp_dir):
+                shark_module = SharkInference(model, (input,),
+                                              device=device,
+                                              dynamic=dynamic,
+                                              jit_trace=True)
+                shark_module.set_frontend("tensorflow")
+                shark_module.compile()
+                results = shark_module.forward((input))
+            assert True == compare_tensors_tf(act_out, results)
+                
+        else:            
+            shark_module = SharkInference(model, (input,),
+                                          device=device,
+                                          dynamic=dynamic,
+                                          jit_trace=True)
+            shark_module.set_frontend("tensorflow")
+            shark_module.compile()
+            results = shark_module.forward((input))
+            assert True == compare_tensors_tf(act_out, results)
 
 
 class XLMRobertaModuleTest(unittest.TestCase):
 
-    def setUp(self):
-        self.module_tester = XLMRobertaModuleTester()
+    @pytest.fixture(autouse=True)
+    def configure(self, pytestconfig):
+        self.module_tester = XLMRobertaModuleTester(self)
+        self.module_tester.save_temps = pytestconfig.getoption("save_temps")
 
-    @pytest.mark.xfail
+    @pytest.mark.skip(reason="Test currently hangs.")
     def test_module_static_cpu(self):
         dynamic = False
         device = "cpu"


### PR DESCRIPTION
also adds/removes some pytest marks to TF tests

Adds pytest option to use IREE's TempFileSaver to generate reproduction artifacts during a test run.

Example usage and results:
![Ex1](https://user-images.githubusercontent.com/87458719/174647012-60903a33-bace-4087-812a-fd220a3ee035.png)
![Ex2](https://user-images.githubusercontent.com/87458719/174647042-d0d316e4-61ac-49ac-8b9b-7ea58437ecaf.png)

