### PR TITLE
Add tf/torch/mhlo/tosa/jax support for SharkDownloader

### DIFF
--- a/tank/tflite/albert_lite_base/albert_lite_base_tflite_mlir_test.py
+++ b/tank/tflite/albert_lite_base/albert_lite_base_tflite_mlir_test.py
@@ -24,7 +24,7 @@ class AlbertTfliteModuleTester:
         self.shark_downloader = SharkDownloader(
             model_name="albert_lite_base",
             tank_url="https://storage.googleapis.com/shark_tank",
-            local_tank_dir="./../gen_shark_tank/tflite",
+            local_tank_dir="./../gen_shark_tank",
             model_type="tflite-tosa",
             input_json="input.json",
             input_type="int32",


### PR DESCRIPTION
Change some path process. Now you can use  sharkdownloder to get mlir file for tf/torch/mhlo/tosa/jax
```
        self.shark_downloader = SharkDownloader(model_name="Bert",
                                                tank_url="https://storage.googleapis.com/shark_tank",
                                                local_tank_dir="./../gen_shark_tank",
                                                model_type="tensorflow")
        tf_mlir_model = self.shark_downloader.get_mlir_file()

        self.shark_downloader = SharkDownloader(model_name="MiniLM-L12-H384-uncased",
                                                tank_url="https://storage.googleapis.com/shark_tank",
                                                local_tank_dir="./../gen_shark_tank",
                                                model_type="torch")
         torch_mlir_model = self.shark_downloader.get_mlir_file()
```

Then use these mlir model as SharkInference model input.

