### PR TITLE
Mark XFail for M1 Vulkan Failures

### DIFF
--- a/tank/convbert-base-turkish-cased_tf/convbert-base-turkish-cased_tf_test.py
+++ b/tank/convbert-base-turkish-cased_tf/convbert-base-turkish-cased_tf_test.py
@@ -50,6 +50,9 @@ class ConvBertModuleTest(unittest.TestCase):
     @pytest.mark.skipif(
         check_device_drivers("vulkan"), reason=device_driver_info("vulkan")
     )
+    @pytest.mark.xfail(
+        reason="Issue: https://github.com/iree-org/iree/issues/9971",
+    )
     def test_module_static_vulkan(self):
         dynamic = False
         device = "vulkan"

--- a/tank/pytorch/alexnet/alexnet_test.py
+++ b/tank/pytorch/alexnet/alexnet_test.py
@@ -86,6 +86,9 @@ class AlexnetModuleTest(unittest.TestCase):
     @pytest.mark.skipif(
         check_device_drivers("vulkan"), reason=device_driver_info("vulkan")
     )
+    @pytest.mark.xfail(
+        reason="Issue known, WIP",
+    )
     def test_module_static_vulkan(self):
         dynamic = False
         device = "vulkan"

--- a/tank/pytorch/mobilebert-uncased/mobilebert-uncased_test.py
+++ b/tank/pytorch/mobilebert-uncased/mobilebert-uncased_test.py
@@ -87,6 +87,9 @@ class MobileBertModuleTest(unittest.TestCase):
     @pytest.mark.skipif(
         check_device_drivers("vulkan"), reason=device_driver_info("vulkan")
     )
+    @pytest.mark.xfail(
+        reason="Issue known, WIP",
+    )
     def test_module_static_vulkan(self):
         dynamic = False
         device = "vulkan"

--- a/tank/pytorch/squeezenet1_0/squeezenet1_0_test.py
+++ b/tank/pytorch/squeezenet1_0/squeezenet1_0_test.py
@@ -96,6 +96,9 @@ class SqueezenetModuleTest(unittest.TestCase):
     @pytest.mark.skipif(
         check_device_drivers("vulkan"), reason=device_driver_info("vulkan")
     )
+    @pytest.mark.xfail(
+        reason="Issue: https://github.com/iree-org/iree/issues/9972",
+    )
     def test_module_dynamic_vulkan(self):
         dynamic = True
         device = "vulkan"


### PR DESCRIPTION
Xfail Marked for:
1. ConvBertModuleTest::test_module_static_vulkan
2. AlexnetModuleTest::test_module_static_vulkan
3. MobileBertModuleTest::test_module_static_vulkan
4. SqueezenetModuleTest::test_module_dynamic_vulkan