### PR TITLE
Make TF32 enabled by default and relax some tolerances if enabled.

### DIFF
--- a/shark/parser.py
+++ b/shark/parser.py
@@ -48,9 +48,9 @@ parser.add_argument(
 )
 parser.add_argument(
     "--enable_tf32",
-    default=False,
-    action="store_true",
-    help="Enables TF32 precision calculations on supported GPUs.",
+    default=True,
+    action="store_false",
+    help="Enables TF32 precision calculations on supported GPUs. True by default.",
 )
 parser.add_argument(
     "--model_config_path",

--- a/tank/albert-base-v2_tf/albert-base-v2_tf_test.py
+++ b/tank/albert-base-v2_tf/albert-base-v2_tf_test.py
@@ -1,6 +1,7 @@
 from shark.iree_utils._common import check_device_drivers, device_driver_info
 from shark.shark_inference import SharkInference
 from shark.shark_downloader import download_tf_model
+from shark.parser import shark_args
 
 import iree.compiler as ireec
 import unittest
@@ -25,7 +26,13 @@ class AlbertBaseModuleTester:
         )
         shark_module.compile()
         result = shark_module.forward(inputs)
-        np.testing.assert_allclose(golden_out, result, rtol=1e-02, atol=1e-03)
+
+        if shark_args.enable_tf32 == True:
+            atol = 1e-01
+        else:
+            atol = 1e-03
+
+        np.testing.assert_allclose(golden_out, result, rtol=1e-02, atol=atol)
 
 
 class AlbertBaseModuleTest(unittest.TestCase):

--- a/tank/bert-base-uncased_tf/bert-base-uncased_tf_test.py
+++ b/tank/bert-base-uncased_tf/bert-base-uncased_tf_test.py
@@ -1,6 +1,7 @@
 from shark.iree_utils._common import check_device_drivers, device_driver_info
 from shark.shark_inference import SharkInference
 from shark.shark_downloader import download_tf_model
+from shark.parser import shark_args
 
 import iree.compiler as ireec
 import unittest
@@ -25,7 +26,13 @@ class BertBaseUncasedModuleTester:
         )
         shark_module.compile()
         result = shark_module.forward(inputs)
-        np.testing.assert_allclose(golden_out, result, rtol=1e-02, atol=1e-03)
+
+        if shark_args.enable_tf32 == True:
+            atol = 1e-01
+        else:
+            atol = 1e-03
+
+        np.testing.assert_allclose(golden_out, result, rtol=1e-02, atol=atol)
 
 
 class BertBaseUncasedModuleTest(unittest.TestCase):

--- a/tank/camembert-base_tf/camembert-base_tf_test.py
+++ b/tank/camembert-base_tf/camembert-base_tf_test.py
@@ -1,6 +1,7 @@
 from shark.iree_utils._common import check_device_drivers, device_driver_info
 from shark.shark_inference import SharkInference
 from shark.shark_downloader import download_tf_model
+from shark.parser import shark_args
 
 import iree.compiler as ireec
 import unittest
@@ -25,7 +26,13 @@ class CamemBertModuleTester:
         )
         shark_module.compile()
         result = shark_module.forward(inputs)
-        np.testing.assert_allclose(golden_out, result, rtol=1e-02, atol=1e-03)
+
+        if shark_args.enable_tf32 == True:
+            atol = 1e-01
+        else:
+            atol = 1e-03
+
+        np.testing.assert_allclose(golden_out, result, rtol=1e-02, atol=atol)
 
 
 class CamemBertModuleTest(unittest.TestCase):

--- a/tank/convbert-base-turkish-cased_tf/convbert-base-turkish-cased_tf_test.py
+++ b/tank/convbert-base-turkish-cased_tf/convbert-base-turkish-cased_tf_test.py
@@ -1,8 +1,8 @@
 from shark.iree_utils._common import check_device_drivers, device_driver_info
 from shark.shark_inference import SharkInference
 from shark.shark_downloader import download_tf_model
+from shark.parser import shark_args
 
-import iree.compiler as ireec
 import unittest
 import pytest
 import numpy as np
@@ -25,7 +25,13 @@ class ConvBertModuleTester:
         )
         shark_module.compile()
         result = shark_module.forward(inputs)
-        np.testing.assert_allclose(golden_out, result, rtol=1e-02, atol=1e-03)
+
+        if shark_args.enable_tf32 == True:
+            atol = 1e-01
+        else:
+            atol = 1e-03
+
+        np.testing.assert_allclose(golden_out, result, rtol=1e-02, atol=atol)
 
 
 class ConvBertModuleTest(unittest.TestCase):

--- a/tank/deberta-base_tf/deberta-base_tf_test.py
+++ b/tank/deberta-base_tf/deberta-base_tf_test.py
@@ -3,12 +3,9 @@ from shark.shark_inference import SharkInference
 from shark.shark_downloader import download_tf_model
 from shark.parser import shark_args
 
-import iree.compiler as ireec
 import unittest
 import pytest
 import numpy as np
-import tempfile
-import os
 
 
 class DebertaBaseModuleTester:
@@ -28,7 +25,13 @@ class DebertaBaseModuleTester:
         )
         shark_module.compile()
         result = shark_module.forward(inputs)
-        np.testing.assert_allclose(golden_out, result, rtol=1e-02, atol=1e-03)
+
+        if shark_args.enable_tf32 == True:
+            atol = 1e-01
+        else:
+            atol = 1e-03
+
+        np.testing.assert_allclose(golden_out, result, rtol=1e-02, atol=atol)
 
 
 class DebertaBaseModuleTest(unittest.TestCase):

--- a/tank/distilbert-base-uncased_tf/distilbert-base-uncased_tf_test.py
+++ b/tank/distilbert-base-uncased_tf/distilbert-base-uncased_tf_test.py
@@ -1,6 +1,7 @@
 from shark.iree_utils._common import check_device_drivers, device_driver_info
 from shark.shark_inference import SharkInference
 from shark.shark_downloader import download_tf_model
+from shark.parser import shark_args
 
 import iree.compiler as ireec
 import unittest
@@ -25,7 +26,13 @@ class DistilBertModuleTester:
         )
         shark_module.compile()
         result = shark_module.forward(inputs)
-        np.testing.assert_allclose(golden_out, result, rtol=1e-02, atol=1e-03)
+
+        if shark_args.enable_tf32 == True:
+            atol = 1e-01
+        else:
+            atol = 1e-03
+
+        np.testing.assert_allclose(golden_out, result, rtol=1e-02, atol=atol)
 
 
 class DistilBertModuleTest(unittest.TestCase):

--- a/tank/electra-small-discriminator_tf/electra-small-discriminator_tf_test.py
+++ b/tank/electra-small-discriminator_tf/electra-small-discriminator_tf_test.py
@@ -1,6 +1,7 @@
 from shark.iree_utils._common import check_device_drivers, device_driver_info
 from shark.shark_inference import SharkInference
 from shark.shark_downloader import download_tf_model
+from shark.parser import shark_args
 
 import iree.compiler as ireec
 import unittest
@@ -25,7 +26,13 @@ class ElectraModuleTester:
         )
         shark_module.compile()
         result = shark_module.forward(inputs)
-        np.testing.assert_allclose(golden_out, result, rtol=1e-02, atol=1e-03)
+
+        if shark_args.enable_tf32 == True:
+            atol = 1e-01
+        else:
+            atol = 1e-03
+
+        np.testing.assert_allclose(golden_out, result, rtol=1e-02, atol=atol)
 
 
 class ElectraModuleTest(unittest.TestCase):

--- a/tank/funnel-transformer_tf/funnel-transformer_tf_test.py
+++ b/tank/funnel-transformer_tf/funnel-transformer_tf_test.py
@@ -1,6 +1,7 @@
 from shark.iree_utils._common import check_device_drivers, device_driver_info
 from shark.shark_inference import SharkInference
 from shark.shark_downloader import download_tf_model
+from shark.parser import shark_args
 
 import iree.compiler as ireec
 import unittest
@@ -25,7 +26,13 @@ class FunnelModuleTester:
         )
         shark_module.compile()
         result = shark_module.forward(inputs)
-        np.testing.assert_allclose(golden_out, result, rtol=1e-02, atol=1e-03)
+
+        if shark_args.enable_tf32 == True:
+            atol = 1e-01
+        else:
+            atol = 1e-03
+
+        np.testing.assert_allclose(golden_out, result, rtol=1e-02, atol=atol)
 
 
 class FunnelModuleTest(unittest.TestCase):

--- a/tank/layoutlm-base-uncased_tf/layoutlm-base-uncased_tf_test.py
+++ b/tank/layoutlm-base-uncased_tf/layoutlm-base-uncased_tf_test.py
@@ -1,6 +1,7 @@
 from shark.iree_utils._common import check_device_drivers, device_driver_info
 from shark.shark_inference import SharkInference
 from shark.shark_downloader import download_tf_model
+from shark.parser import shark_args
 
 import iree.compiler as ireec
 import unittest
@@ -25,7 +26,13 @@ class LayoutLMModuleTester:
         )
         shark_module.compile()
         result = shark_module.forward(inputs)
-        np.testing.assert_allclose(golden_out, result, rtol=1e-02, atol=1e-03)
+
+        if shark_args.enable_tf32 == True:
+            atol = 1e-01
+        else:
+            atol = 1e-03
+
+        np.testing.assert_allclose(golden_out, result, rtol=1e-02, atol=atol)
 
 
 class LayoutLMModuleTest(unittest.TestCase):

--- a/tank/longformer-base-4096_tf/longformer-base-4096_tf_test.py
+++ b/tank/longformer-base-4096_tf/longformer-base-4096_tf_test.py
@@ -1,6 +1,7 @@
 from shark.iree_utils._common import check_device_drivers, device_driver_info
 from shark.shark_inference import SharkInference
 from shark.shark_downloader import download_tf_model
+from shark.parser import shark_args
 
 import iree.compiler as ireec
 import unittest
@@ -25,7 +26,13 @@ class LongformerModuleTester:
         )
         shark_module.compile()
         result = shark_module.forward(inputs)
-        np.testing.assert_allclose(golden_out, result, rtol=1e-02, atol=1e-03)
+
+        if shark_args.enable_tf32 == True:
+            atol = 1e-02
+        else:
+            atol = 1e-03
+
+        np.testing.assert_allclose(golden_out, result, rtol=1e-02, atol=atol)
 
 
 class LongformerModuleTest(unittest.TestCase):

--- a/tank/mobilebert-uncased_tf/mobilebert-uncased_tf_test.py
+++ b/tank/mobilebert-uncased_tf/mobilebert-uncased_tf_test.py
@@ -1,6 +1,7 @@
 from shark.iree_utils._common import check_device_drivers, device_driver_info
 from shark.shark_inference import SharkInference
 from shark.shark_downloader import download_tf_model
+from shark.parser import shark_args
 
 import iree.compiler as ireec
 import unittest
@@ -25,7 +26,13 @@ class MobileBertModuleTester:
         )
         shark_module.compile()
         result = shark_module.forward(inputs)
-        np.testing.assert_allclose(golden_out, result, rtol=1e-02, atol=1e-03)
+
+        if shark_args.enable_tf32 == True:
+            atol = 1e-01
+        else:
+            atol = 1e-03
+
+        np.testing.assert_allclose(golden_out, result, rtol=1e-02, atol=atol)
 
 
 class MobileBertModuleTest(unittest.TestCase):

--- a/tank/model_utils.py
+++ b/tank/model_utils.py
@@ -1,4 +1,5 @@
 from shark.shark_inference import SharkInference
+from shark.parser import shark_args
 
 import torch
 import numpy as np
@@ -101,6 +102,9 @@ def get_vision_model(torch_model):
 def compare_tensors(torch_tensor, numpy_tensor):
     # setting the absolute and relative tolerance
     rtol = 1e-02
-    atol = 1e-03
+    if shark_args.enable_tf32 == True:
+        atol = 1e-02
+    else:
+        atol = 1e-03
     # torch_to_numpy = torch_tensor.detach().numpy()
     return np.allclose(torch_tensor, numpy_tensor, rtol, atol)

--- a/tank/mpnet-base_tf/mpnet-base_tf_test.py
+++ b/tank/mpnet-base_tf/mpnet-base_tf_test.py
@@ -1,6 +1,7 @@
 from shark.iree_utils._common import check_device_drivers, device_driver_info
 from shark.shark_inference import SharkInference
 from shark.shark_downloader import download_tf_model
+from shark.parser import shark_args
 
 import iree.compiler as ireec
 import unittest
@@ -25,7 +26,13 @@ class MpNetModuleTester:
         )
         shark_module.compile()
         result = shark_module.forward(inputs)
-        np.testing.assert_allclose(golden_out, result, rtol=1e-02, atol=1e-03)
+
+        if shark_args.enable_tf32 == True:
+            atol = 1e-01
+        else:
+            atol = 1e-03
+
+        np.testing.assert_allclose(golden_out, result, rtol=1e-02, atol=atol)
 
 
 class MpNetModuleTest(unittest.TestCase):

--- a/tank/rembert_tf/rembert_tf_test.py
+++ b/tank/rembert_tf/rembert_tf_test.py
@@ -1,6 +1,7 @@
 from shark.iree_utils._common import check_device_drivers, device_driver_info
 from shark.shark_inference import SharkInference
 from shark.shark_downloader import download_tf_model
+from shark.parser import shark_args
 
 import iree.compiler as ireec
 import unittest
@@ -25,7 +26,13 @@ class RemBertModuleTester:
         )
         shark_module.compile()
         result = shark_module.forward(inputs)
-        np.testing.assert_allclose(golden_out, result, rtol=1e-02, atol=1e-03)
+
+        if shark_args.enable_tf32 == True:
+            atol = 1e-01
+        else:
+            atol = 1e-03
+
+        np.testing.assert_allclose(golden_out, result, rtol=1e-02, atol=atol)
 
 
 class RemBertModuleTest(unittest.TestCase):

--- a/tank/roberta-base_tf/roberta-base_tf_test.py
+++ b/tank/roberta-base_tf/roberta-base_tf_test.py
@@ -7,8 +7,6 @@ import iree.compiler as ireec
 import unittest
 import pytest
 import numpy as np
-import tempfile
-import os
 
 
 class RobertaBaseModuleTester:
@@ -28,7 +26,13 @@ class RobertaBaseModuleTester:
         )
         shark_module.compile()
         result = shark_module.forward(inputs)
-        np.testing.assert_allclose(golden_out, result, rtol=1e-02, atol=1e-03)
+
+        if shark_args.enable_tf32 == True:
+            atol = 1e-01
+        else:
+            atol = 1e-03
+
+        np.testing.assert_allclose(golden_out, result, rtol=1e-02, atol=atol)
 
 
 class RobertaBaseModuleTest(unittest.TestCase):

--- a/tank/tapas-base_tf/tapas-base_tf_test.py
+++ b/tank/tapas-base_tf/tapas-base_tf_test.py
@@ -1,6 +1,7 @@
 from shark.iree_utils._common import check_device_drivers, device_driver_info
 from shark.shark_inference import SharkInference
 from shark.shark_downloader import download_tf_model
+from shark.parser import shark_args
 
 import iree.compiler as ireec
 import unittest
@@ -25,7 +26,13 @@ class TapasBaseModuleTester:
         )
         shark_module.compile()
         result = shark_module.forward(inputs)
-        np.testing.assert_allclose(golden_out, result, rtol=1e-02, atol=1e-03)
+
+        if shark_args.enable_tf32 == True:
+            atol = 1e-01
+        else:
+            atol = 1e-03
+
+        np.testing.assert_allclose(golden_out, result, rtol=1e-02, atol=atol)
 
 
 class TapasBaseModuleTest(unittest.TestCase):

--- a/tank/tiny-random-flaubert_tf/tiny-random-flaubert_tf_test.py
+++ b/tank/tiny-random-flaubert_tf/tiny-random-flaubert_tf_test.py
@@ -1,6 +1,7 @@
 from shark.iree_utils._common import check_device_drivers, device_driver_info
 from shark.shark_inference import SharkInference
 from shark.shark_downloader import download_tf_model
+from shark.parser import shark_args
 
 import iree.compiler as ireec
 import unittest
@@ -25,7 +26,13 @@ class FlauBertModuleTester:
         )
         shark_module.compile()
         result = shark_module.forward(inputs)
-        np.testing.assert_allclose(golden_out, result, rtol=1e-02, atol=1e-03)
+
+        if shark_args.enable_tf32 == True:
+            atol = 1e-01
+        else:
+            atol = 1e-03
+
+        np.testing.assert_allclose(golden_out, result, rtol=1e-02, atol=atol)
 
 
 class FlauBertModuleTest(unittest.TestCase):

--- a/tank/xlm-roberta-base_tf/xlm-roberta-base_tf_test.py
+++ b/tank/xlm-roberta-base_tf/xlm-roberta-base_tf_test.py
@@ -1,6 +1,7 @@
 from shark.iree_utils._common import check_device_drivers, device_driver_info
 from shark.shark_inference import SharkInference
 from shark.shark_downloader import download_tf_model
+from shark.parser import shark_args
 
 import iree.compiler as ireec
 import unittest
@@ -25,7 +26,13 @@ class XLMRobertaModuleTester:
         )
         shark_module.compile()
         result = shark_module.forward(inputs)
-        np.testing.assert_allclose(golden_out, result, rtol=1e-02, atol=1e-03)
+
+        if shark_args.enable_tf32 == True:
+            atol = 1e-01
+        else:
+            atol = 1e-03
+
+        np.testing.assert_allclose(golden_out, result, rtol=1e-02, atol=atol)
 
 
 class XLMRobertaModuleTest(unittest.TestCase):


### PR DESCRIPTION
`--enable_tf32` is now True by default and certain TF model tests have a switch for relaxing tolerances if TF32 calculations are enabled.