### PR TITLE
Add benchmarks to MHLO miniLM and resnet50 and fix some issues with tolerances for TF32.

### DIFF
--- a/shark/parser.py
+++ b/shark/parser.py
@@ -48,8 +48,8 @@ parser.add_argument(
 )
 parser.add_argument(
     "--enable_tf32",
+    type=bool,
     default=False,
-    action="store_true",
     help="Enables TF32 precision calculations on supported GPUs.",
 )
 parser.add_argument(

--- a/shark/shark_benchmark_runner.py
+++ b/shark/shark_benchmark_runner.py
@@ -76,7 +76,7 @@ class SharkBenchmarkRunner(SharkRunner):
         torch_device = torch.device(
             "cuda:0" if self.device == "gpu" else "cpu"
         )
-        HFmodel, input, expected_output = get_torch_model(modelname)[:2]
+        HFmodel, input = get_torch_model(modelname)[:2]
         frontend_model = HFmodel.model
         frontend_model.to(torch_device)
         input.to(torch_device)
@@ -102,7 +102,9 @@ class SharkBenchmarkRunner(SharkRunner):
         import tensorflow as tf
         from tank.model_utils_tf import get_tf_model
 
-        model, input, expected_output = get_tf_model(modelname)
+        model, input, = get_tf_model(
+            modelname
+        )[:2]
         frontend_model = model
 
         for i in range(shark_args.num_warmup_iterations):

--- a/shark/shark_benchmark_runner.py
+++ b/shark/shark_benchmark_runner.py
@@ -19,7 +19,6 @@ from shark.iree_utils.benchmark_utils import (
     run_benchmark_module,
 )
 from shark.parser import shark_args
-from tank.model_utils import get_torch_model
 from datetime import datetime
 import time
 import csv
@@ -58,16 +57,17 @@ class SharkBenchmarkRunner(SharkRunner):
             input_tensors,
             mlir_dialect=self.mlir_dialect,
         )
-        print(self.benchmark_cl)
+        # print(self.benchmark_cl)
 
-    def benchmark_frontend(self, inputs, modelname):
+    def benchmark_frontend(self, modelname):
         if self.mlir_dialect in ["linalg", "torch"]:
             return self.benchmark_torch(modelname)
         elif self.mlir_dialect in ["mhlo", "tf"]:
-            return self.benchmark_tf(inputs, modelname)
+            return self.benchmark_tf(modelname)
 
     def benchmark_torch(self, modelname):
         import torch
+        from tank.model_utils import get_torch_model
 
         if self.device == "gpu":
             torch.set_default_tensor_type(torch.cuda.FloatTensor)
@@ -76,7 +76,7 @@ class SharkBenchmarkRunner(SharkRunner):
         torch_device = torch.device(
             "cuda:0" if self.device == "gpu" else "cpu"
         )
-        HFmodel, input, act_out = get_torch_model(modelname)
+        HFmodel, input, expected_output = get_torch_model(modelname)[:2]
         frontend_model = HFmodel.model
         frontend_model.to(torch_device)
         input.to(torch_device)
@@ -98,26 +98,32 @@ class SharkBenchmarkRunner(SharkRunner):
             f"{((end-begin)/shark_args.num_iterations)*1000}",
         ]
 
-    def benchmark_tf(self, frontend_model, inputs):
-        # for i in range(shark_args.num_warmup_iterations):
-        #    frontend_model.forward(*inputs)
+    def benchmark_tf(self, modelname):
+        import tensorflow as tf
+        from tank.model_utils_tf import get_tf_model
 
-        # begin = time.time()
-        # for i in range(shark_args.num_iterations):
-        #    out = frontend_model.forward(*inputs)
-        #    if i == shark_args.num_iterations - 1:
-        #        end = time.time()
-        #        break
-        # print(
-        #    f"TF benchmark:{shark_args.num_iterations/(end-begin)} iter/second, Total Iterations:{shark_args.num_iterations}"
-        # )
-        # return [
-        #    f"{shark_args.num_iterations/(end-begin)}",
-        #    f"{((end-begin)/shark_args.num_iterations)*1000}",
-        # ]
-        return ["n/a", "n/a"]
+        model, input, expected_output = get_tf_model(modelname)
+        frontend_model = model
+
+        for i in range(shark_args.num_warmup_iterations):
+            frontend_model.forward(*input)
+
+        begin = time.time()
+        for i in range(shark_args.num_iterations):
+            out = frontend_model.forward(*input)
+            if i == shark_args.num_iterations - 1:
+                end = time.time()
+                break
+        print(
+            f"TF benchmark:{shark_args.num_iterations/(end-begin)} iter/second, Total Iterations:{shark_args.num_iterations}"
+        )
+        return [
+            f"{shark_args.num_iterations/(end-begin)}",
+            f"{((end-begin)/shark_args.num_iterations)*1000}",
+        ]
 
     def benchmark_c(self):
+        print(self.benchmark_cl)
         result = run_benchmark_module(self.benchmark_cl)
         print(f"Shark-IREE-C benchmark:{result} iter/second")
         return [f"{result}", f"{1000/result}"]
@@ -140,25 +146,22 @@ class SharkBenchmarkRunner(SharkRunner):
             f"{((end-begin)/shark_args.num_iterations)*1000}",
         ]
 
-    def benchmark_all(self, inputs: tuple):
-        self.benchmark_frontend(inputs)
-        self.benchmark_python(inputs)
-        self.benchmark_c()
-
     def benchmark_all_csv(
         self, inputs: tuple, modelname, dynamic, device_str, frontend
     ):
         self.setup_cl(inputs)
         field_names = [
             "model",
-            "platform",
+            "engine",
             "dynamic",
+            "dialect",
             "device",
             "iter/sec",
             "ms/iter",
+            "iterations",
             "datetime",
         ]
-        platforms = ["frontend", "shark_python", "shark_iree_c"]
+        engines = ["frontend", "shark_python", "shark_iree_c"]
 
         if not os.path.exists("bench_results.csv"):
             with open("bench_results.csv", mode="w", newline="") as f:
@@ -174,22 +177,24 @@ class SharkBenchmarkRunner(SharkRunner):
             else:
                 bench_result["dynamic"] = "False"
             bench_result["device"] = device_str
-            for p in platforms:
-                if p == "frontend":
-                    bench_result["platform"] = frontend
+            for e in engines:
+                if e == "frontend":
+                    bench_result["engine"] = frontend
                     bench_result["iter/sec"] = self.benchmark_frontend(
-                        inputs, modelname
+                        modelname
                     )[0]
                     bench_result["ms/iter"] = self.benchmark_frontend(
-                        inputs, modelname
+                        modelname
                     )[1]
-                elif p == "shark_python":
-                    bench_result["platform"] = "shark_python"
+                elif e == "shark_python":
+                    bench_result["engine"] = "shark_python"
                     bench_result["iter/sec"] = self.benchmark_python(inputs)[0]
                     bench_result["ms/iter"] = self.benchmark_python(inputs)[1]
                 else:
-                    bench_result["platform"] = "shark_iree_c"
+                    bench_result["engine"] = "shark_iree_c"
                     bench_result["iter/sec"] = self.benchmark_c()[0]
                     bench_result["ms/iter"] = self.benchmark_c()[1]
+                bench_result["dialect"] = self.mlir_dialect
+                bench_result["iterations"] = shark_args.num_iterations
                 bench_result["datetime"] = str(datetime.now())
                 writer.writerow(bench_result)

--- a/tank/MiniLM-L12-H384-uncased/MiniLM-L12-H384-uncased_test.py
+++ b/tank/MiniLM-L12-H384-uncased/MiniLM-L12-H384-uncased_test.py
@@ -1,6 +1,7 @@
 from shark.iree_utils._common import check_device_drivers, device_driver_info
 from shark.shark_inference import SharkInference
 from shark.shark_downloader import download_tf_model
+from shark.parser import shark_args
 
 import iree.compiler as ireec
 import unittest
@@ -19,13 +20,32 @@ class MiniLMModuleTester:
         model, func_name, inputs, golden_out = download_tf_model(
             "microsoft/MiniLM-L12-H384-uncased"
         )
+        shark_args.enable_tf32 = self.benchmark
 
         shark_module = SharkInference(
-            model, func_name, device=device, mlir_dialect="mhlo"
+            model,
+            func_name,
+            device=device,
+            mlir_dialect="mhlo",
+            is_benchmark=self.benchmark,
         )
         shark_module.compile()
         result = shark_module.forward(inputs)
-        np.testing.assert_allclose(golden_out, result, rtol=1e-02, atol=1e-03)
+        rtol = 1e-02
+        atol = 1e-03
+        if self.benchmark == True:
+            rtol = 1e-01
+            atol = 1e-02
+            shark_module.shark_runner.benchmark_all_csv(
+                (inputs),
+                "microsoft/MiniLM-L12-H384-uncased",
+                dynamic,
+                device,
+                "tensorflow",
+            )
+            shark_args.enable_tf32 = False
+
+        np.testing.assert_allclose(golden_out, result, rtol=rtol, atol=atol)
 
 
 class MiniLMModuleTest(unittest.TestCase):
@@ -39,7 +59,6 @@ class MiniLMModuleTest(unittest.TestCase):
         device = "cpu"
         self.module_tester.create_and_check_module(dynamic, device)
 
-    @pytest.mark.skip(reason="MiniLM numerics issues on gpu")
     @pytest.mark.skipif(
         check_device_drivers("gpu"), reason=device_driver_info("gpu")
     )

--- a/tank/MiniLM-L12-H384-uncased/MiniLM-L12-H384-uncased_test.py
+++ b/tank/MiniLM-L12-H384-uncased/MiniLM-L12-H384-uncased_test.py
@@ -29,11 +29,9 @@ class MiniLMModuleTester:
             mlir_dialect="mhlo",
             is_benchmark=self.benchmark,
         )
-        shark_module.compile()
-        result = shark_module.forward(inputs)
-        rtol = 1e-02
-        atol = 1e-03
         if self.benchmark == True:
+            shark_args.enable_tf32 = True
+            shark_module.compile()
             rtol = 1e-01
             atol = 1e-02
             shark_module.shark_runner.benchmark_all_csv(
@@ -45,6 +43,12 @@ class MiniLMModuleTester:
             )
             shark_args.enable_tf32 = False
 
+        else:
+            shark_module.compile()
+            rtol = 1e-02
+            atol = 1e-03
+
+        result = shark_module.forward(inputs)
         np.testing.assert_allclose(golden_out, result, rtol=rtol, atol=atol)
 
 

--- a/tank/MiniLM-L12-H384-uncased_torch/MiniLM-L12-H384-uncased_torch_test.py
+++ b/tank/MiniLM-L12-H384-uncased_torch/MiniLM-L12-H384-uncased_torch_test.py
@@ -42,6 +42,8 @@ class MiniLMModuleTester:
             atol = 1e-02
         else:
             shark_module.compile()
+            rtol = 1e-02
+            atol = 1e-03
 
         results = shark_module.forward(input)
         assert True == compare_tensors(act_out, results, rtol, atol)

--- a/tank/MiniLM-L12-H384-uncased_torch/MiniLM-L12-H384-uncased_torch_test.py
+++ b/tank/MiniLM-L12-H384-uncased_torch/MiniLM-L12-H384-uncased_torch_test.py
@@ -2,6 +2,7 @@ from shark.shark_inference import SharkInference
 from shark.iree_utils._common import check_device_drivers, device_driver_info
 from tank.model_utils import compare_tensors
 from shark.shark_downloader import download_torch_model
+from shark.parser import shark_args
 
 import unittest
 import numpy as np
@@ -19,17 +20,7 @@ class MiniLMModuleTester:
         model_mlir, func_name, input, act_out = download_torch_model(
             "microsoft/MiniLM-L12-H384-uncased", dynamic
         )
-
-        # from shark.shark_importer import SharkImporter
-        # mlir_importer = SharkImporter(
-        #    model,
-        #    (input,),
-        #    frontend="torch",
-        # )
-        # minilm_mlir, func_name = mlir_importer.import_mlir(
-        #    is_dynamic=dynamic, tracing_required=True
-        # )
-
+        shark_args.enable_tf32 = self.benchmark
         shark_module = SharkInference(
             model_mlir,
             func_name,
@@ -49,6 +40,7 @@ class MiniLMModuleTester:
                 device,
                 "torch",
             )
+            shark_args.enable_tf32 = False
 
 
 class MiniLMModuleTest(unittest.TestCase):

--- a/tank/model_utils.py
+++ b/tank/model_utils.py
@@ -99,12 +99,6 @@ def get_vision_model(torch_model):
 ################################################################################
 
 # Utility function for comparing two tensors (torch).
-def compare_tensors(torch_tensor, numpy_tensor):
-    # setting the absolute and relative tolerance
-    rtol = 1e-02
-    atol = 1e-03
-    if shark_args.enable_tf32 == True:
-        rtol = 1e-01
-        atol = 1e-02
+def compare_tensors(torch_tensor, numpy_tensor, rtol=1e-02, atol=1e-03):
     # torch_to_numpy = torch_tensor.detach().numpy()
     return np.allclose(torch_tensor, numpy_tensor, rtol, atol)

--- a/tank/model_utils.py
+++ b/tank/model_utils.py
@@ -1,4 +1,5 @@
 from shark.shark_inference import SharkInference
+from shark.parser import shark_args
 
 import torch
 import numpy as np
@@ -102,5 +103,8 @@ def compare_tensors(torch_tensor, numpy_tensor):
     # setting the absolute and relative tolerance
     rtol = 1e-02
     atol = 1e-03
+    if shark_args.enable_tf32 == True:
+        rtol = 1e-01
+        atol = 1e-02
     # torch_to_numpy = torch_tensor.detach().numpy()
     return np.allclose(torch_tensor, numpy_tensor, rtol, atol)


### PR DESCRIPTION
NOTE: benchmark reference numbers from TF on GPU are showing CPU results as GPUs are disabled in tf.config.
It's a bit tricky to navigate TF GPU execution/visibility so that will come in a follow-up.