### PR TITLE
Don't remove the latest .whl package from CI.

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -111,7 +111,6 @@ jobs:
             gsutil -m cp -r gs://shark_tank/$SHA/* gs://shark_tank/latest/
         fi
         rm pytest_results.txt
-        rm -rf ./wheelhouse/nodai*
 
     
     - name: Upload Release Assets


### PR DESCRIPTION
Previously, the CI was removing the latest package and pointing to the
stale package.