### PR TITLE
Add some metadata and features to benchmark results.

### DIFF
--- a/tank/pytorch/bench_results.csv
+++ b/tank/pytorch/bench_results.csv
@@ -1,1 +1,0 @@
-platform,model,dynamic,device,iter/sec,ms/iter,datetime

--- a/tank/pytorch/torch_model_list.csv
+++ b/tank/pytorch/torch_model_list.csv
@@ -1,18 +1,18 @@
-model_name, use_tracing, model_type, dynamic
-microsoft/MiniLM-L12-H384-uncased,True,hf,True
-albert-base-v2,True,hf,True
-bert-base-uncased,True,hf,True
-bert-base-cased,True,hf,True
-google/mobilebert-uncased,True,hf,True
-alexnet,False,vision,True
-resnet18,False,vision,True
-resnet50,False,vision,True
-resnet101,False,vision,True
-squeezenet1_0,False,vision,True
-wide_resnet50_2,False,vision,True
-mobilenet_v3_small,False,vision,True
-google/vit-base-patch16-224,True,hf_img_cls,False
-microsoft/resnet-50,True,hf_img_cls,False
-facebook/deit-small-distilled-patch16-224,True,hf_img_cls,False
-microsoft/beit-base-patch16-224-pt22k-ft22k,True,hf_img_cls,False
-nvidia/mit-b0,True,hf_img_cls,False
+model_name, use_tracing, model_type, dynamic, param_count, tags, notes
+microsoft/MiniLM-L12-H384-uncased,True,hf,True,66M,"nlp,bert-variant,transformer-encoder","Large version has 12 layers, 384 hidden size,Smaller than BERTbase (66M params vs 109M params)"
+albert-base-v2,True,hf,True,11M,"nlp,bert-variant,transformer-encoder","12 layers, 128 embedding dim, 768 hidden dim, 12 attention heads,Smaller than BERTbase (11M params vs 109M params),Uses weight sharing to reduce # params but computational cost is similar to BERT."
+bert-base-uncased,True,hf,True,109M,"nlp,bert-variant,transformer-encoder","12 layers, 768 hidden, 12 attention heads"
+bert-base-cased,True,hf,True,109M,"nlp,bert-variant,transformer-encoder","12 layers, 768 hidden, 12 attention heads"
+google/mobilebert-uncased,True,hf,True,25M,"nlp,bert-variant,transformer-encoder,mobile","24 layers, 512 hidden size, 128 embedding"
+alexnet,False,vision,True,61M,"cnn,parallel-layers","The CNN that revolutionized computer vision (move away from hand-crafted features to neural networks),10 years old now and probably no longer used in prod."
+resnet18,False,vision,True,11M,"cnn,image-classification,residuals,resnet-variant","1 7x7 conv2d and the rest are 3x3 conv2d"
+resnet50,False,vision,True,23M,"cnn,image-classification,residuals,resnet-variant","Bottlenecks with only conv2d (1x1 conv -> 3x3 conv -> 1x1 conv blocks)"
+resnet101,False,vision,True,29M,"cnn,image-classification,residuals,resnet-variant","Bottlenecks with only conv2d (1x1 conv -> 3x3 conv -> 1x1 conv blocks)"
+squeezenet1_0,False,vision,True,1.25M,"cnn,image-classification,mobile,parallel-layers","Parallel conv2d (1x1 conv to compress -> (3x3 expand | 1x1 expand) -> concat)"
+wide_resnet50_2,False,vision,True,69M,"cnn,image-classification,residuals,resnet-variant","Resnet variant where model depth is decreased and width is increased."
+mobilenet_v3_small,False,vision,True,2.5M,"image-classification,cnn,mobile",N/A
+google/vit-base-patch16-224,True,hf_img_cls,False,86M,"image-classification,vision-transformer,transformer-encoder",N/A
+microsoft/resnet-50,True,hf_img_cls,False,23M,"image-classification,cnn,residuals,resnet-variant","Bottlenecks with only conv2d (1x1 conv -> 3x3 conv -> 1x1 conv blocks)"
+facebook/deit-small-distilled-patch16-224,True,hf_img_cls,False,22M,"image-classification,vision-transformer,cnn",N/A
+microsoft/beit-base-patch16-224-pt22k-ft22k,True,hf_img_cls,False,86M,"image-classification,transformer-encoder,bert-variant,vision-transformer",N/A
+nvidia/mit-b0,True,hf_img_cls,False,3.7M,"image-classification,transformer-encoder",SegFormer


### PR DESCRIPTION
- Rename "dynamic" bool field to "shape_type" and provide "static" or "dynamic" as values.
- Provide datatype in benchmark results.
- Computes and provides comparison with PyTorch (or Tensorflow) for shark-python and shark-iree-c benchmarks (e.g. 2x slower/faster)
- Adds tags and notes to tank/pytorch/torch_model_list.csv to be added to the first entry row (PT/TF benchmark) for every benchmarked test case.

Example:
```
model,engine,dialect,device,shape_type,data_type,iter/sec,ms/iter,vs. PyTorch/TF,iterations,param_count,tags,notes,datetime
microsoft/MiniLM-L12-H384-uncased,tensorflow,mhlo,cpu,static,int32,17.557325179243154,56.956284046173096,=,100,66M,"nlp,bert-variant,transformer-encoder","Large version has 12 layers, 384 hidden size,Smaller than BERTbase (66M params vs 109M params)",2022-08-27 02:41:01.053269
microsoft/MiniLM-L12-H384-uncased,shark_python,mhlo,cpu,static,int32,31.806993922301466,31.439626216888428,1.81x faster,100,,,,2022-08-27 02:41:04.414347
microsoft/MiniLM-L12-H384-uncased,shark_iree_c,mhlo,cpu,static,int32,36.36363636363637,27.499999999999996,2.07x faster,100,,,,2022-08-27 02:41:05.494994
```