### PR TITLE
Enable CPU benchmarks on test-models workflows.

### DIFF
--- a/.github/workflows/test-models.yml
+++ b/.github/workflows/test-models.yml
@@ -90,6 +90,7 @@ jobs:
         source shark.venv/bin/activate
         pytest --benchmark tank/ -k cpu
         gsutil cp ./bench_results.csv gs://shark-public/builder/bench_results/${DATE}/bench_results_cpu_${SHORT_SHA}.csv
+        gsutil cp gs://shark-public/builder/bench_results/${DATE}/bench_results_cpu_${SHORT_SHA}.csv gs://shark-public/builder/bench_results/latest/bench_results_cpu_latest.csv
 
     - name: Validate GPU Models
       if: matrix.suite == 'gpu'
@@ -99,6 +100,7 @@ jobs:
         source shark.venv/bin/activate
         pytest --benchmark -k "gpu" --ignore=shark/tests/test_shark_importer.py --ignore=benchmarks/tests/test_hf_benchmark.py --ignore=benchmarks/tests/test_benchmark.py 
         gsutil cp ./bench_results.csv gs://shark-public/builder/bench_results/${DATE}/bench_results_gpu_${SHORT_SHA}.csv
+        gsutil cp gs://shark-public/builder/bench_results/${DATE}/bench_results_gpu_${SHORT_SHA}.csv gs://shark-public/builder/bench_results/latest/bench_results_gpu_latest.csv
 
     - name: Validate Vulkan Models
       if: matrix.suite == 'vulkan'

--- a/.github/workflows/test-models.yml
+++ b/.github/workflows/test-models.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        os: [a100, MacStudio, ubuntu-latest]
+        os: [a100, MacStudio, ubuntu-latest, icelake]
         suite: [cpu,gpu,vulkan]
         python-version: ["3.10"]
         include:
@@ -32,6 +32,12 @@ jobs:
             suite: gpu
           - os: MacStudio
             suite: cpu
+          - os: icelake
+            suite: gpu
+          - os: icelake
+            suite: vulkan
+          - os: a100
+            suite: cpu
 
     runs-on: ${{ matrix.os }}
 
@@ -44,13 +50,13 @@ jobs:
         echo "DATE=$(date +'%Y-%m-%d')" >> $GITHUB_ENV
         
     - name: Set up Python Version File ${{ matrix.python-version }}
-      if: matrix.os == 'a100' ||  matrix.os == 'ubuntu-latest'
+      if: matrix.os == 'a100' ||  matrix.os == 'ubuntu-latest' ||  matrix.os == 'icelake'
       run: |
         # See https://github.com/actions/setup-python/issues/433
         echo ${{ matrix.python-version }} >> $GITHUB_WORKSPACE/.python-version
     
     - name: Set up Python ${{ matrix.python-version }}
-      if: matrix.os == 'a100' ||  matrix.os == 'ubuntu-latest'
+      if: matrix.os == 'a100' ||  matrix.os == 'ubuntu-latest' ||  matrix.os == 'icelake'
       uses: actions/setup-python@v4
       with:
         python-version: '${{ matrix.python-version }}'
@@ -82,7 +88,8 @@ jobs:
         cd $GITHUB_WORKSPACE
         PYTHON=python${{ matrix.python-version }} IMPORTER=1 ./setup_venv.sh
         source shark.venv/bin/activate
-        pytest -k 'cpu' --ignore=shark/tests/test_shark_importer.py --ignore=benchmarks/tests/test_hf_benchmark.py --ignore=benchmarks/tests/test_benchmark.py 
+        pytest --benchmark tank/ -k cpu
+        gsutil cp ./bench_results.csv gs://shark-public/builder/bench_results/${DATE}/bench_results_cpu_${SHORT_SHA}.csv
 
     - name: Validate GPU Models
       if: matrix.suite == 'gpu'

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ pytest tank/tf/hf_masked_lm/albert-base-v2_test.py::AlbertBaseModuleTest::test_m
 
 
 <details>
-  <summary>Testing</summary>
+  <summary>Testing and Benchmarks</summary>
 
 ### Run all model tests on CPU/GPU/VULKAN/Metal
 ```shell
@@ -122,7 +122,11 @@ pytest tank/<MODEL_NAME> -k "keyword"
 
 ### Run benchmarks on SHARK tank pytests and generate bench_results.csv with results.
 
-(requires source installation with `IMPORTER=1 ./setup_venv.sh`)
+Note: Latest benchmarks on our canonical machines can be found here:
+https://storage.googleapis.com/shark-public/builder/bench_results/latest/bench_results_cpu_latest.csv
+https://storage.googleapis.com/shark-public/builder/bench_results/latest/bench_results_gpu_latest.csv
+  
+(the following requires source installation with `IMPORTER=1 ./setup_venv.sh`)
 
 ```shell
 pytest --benchmark tank


### PR DESCRIPTION
Also copies latest benchmarks to:

gs://shark-public/builder/bench_results/latest/bench_results_cpu_latest.csv
gs://shark-public/builder/bench_results/latest/bench_results_gpu_latest.csv
