### PR TITLE
Add pytest option to specify a URL for shark tank artifacts.

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -42,3 +42,9 @@ def pytest_addoption(parser):
         default="None",
         help="Passes the github SHA of the CI workflow to include in google storage directory for reproduction artifacts.",
     )
+    parser.addoption(
+        "--tank_url",
+        type=str,
+        default="gs://shark_tank/latest",
+        help="URL to bucket from which to download SHARK tank artifacts. Default is gs://shark_tank/latest",
+    )

--- a/shark/shark_downloader.py
+++ b/shark/shark_downloader.py
@@ -79,7 +79,7 @@ def check_dir_exists(model_name, frontend="torch", dynamic=""):
 
 # Downloads the torch model from gs://shark_tank dir.
 def download_torch_model(
-    model_name, dynamic=False, shark_default_sha="latest"
+    model_name, dynamic=False, tank_url="gs://shark_tank/latest"
 ):
     model_name = model_name.replace("/", "_")
     dyn_str = "_dynamic" if dynamic else ""
@@ -88,8 +88,8 @@ def download_torch_model(
 
     def gs_download_model():
         gs_command = (
-            'gsutil -o "GSUtil:parallel_process_count=1" cp -r gs://shark_tank/'
-            + shark_default_sha
+            'gsutil -o "GSUtil:parallel_process_count=1" cp -r '
+            + tank_url
             + "/"
             + model_dir_name
             + " "
@@ -104,8 +104,8 @@ def download_torch_model(
         model_dir = os.path.join(WORKDIR, model_dir_name)
         local_hash = str(np.load(os.path.join(model_dir, "hash.npy")))
         gs_hash = (
-            'gsutil -o "GSUtil:parallel_process_count=1" cp gs://shark_tank/'
-            + shark_default_sha
+            'gsutil -o "GSUtil:parallel_process_count=1" cp '
+            + tank_url
             + "/"
             + model_dir_name
             + "/hash.npy"
@@ -142,7 +142,7 @@ def download_torch_model(
 
 # Downloads the tflite model from gs://shark_tank dir.
 def download_tflite_model(
-    model_name, dynamic=False, shark_default_sha="latest"
+    model_name, dynamic=False, tank_url="gs://shark_tank/latest"
 ):
     dyn_str = "_dynamic" if dynamic else ""
     os.makedirs(WORKDIR, exist_ok=True)
@@ -150,8 +150,8 @@ def download_tflite_model(
 
     def gs_download_model():
         gs_command = (
-            'gsutil -o "GSUtil:parallel_process_count=1" cp -r gs://shark_tank/'
-            + shark_default_sha
+            'gsutil -o "GSUtil:parallel_process_count=1" cp -r '
+            + tank_url
             + "/"
             + model_dir_name
             + " "
@@ -168,8 +168,8 @@ def download_tflite_model(
         model_dir = os.path.join(WORKDIR, model_dir_name)
         local_hash = str(np.load(os.path.join(model_dir, "hash.npy")))
         gs_hash = (
-            'gsutil -o "GSUtil:parallel_process_count=1" cp gs://shark_tank/'
-            + shark_default_sha
+            'gsutil -o "GSUtil:parallel_process_count=1" cp '
+            + tank_url
             + "/"
             + model_dir_name
             + "/hash.npy"
@@ -204,15 +204,17 @@ def download_tflite_model(
     return mlir_file, function_name, inputs_tuple, golden_out_tuple
 
 
-def download_tf_model(model_name, tuned=None, shark_default_sha="latest"):
+def download_tf_model(
+    model_name, tuned=None, tank_url="gs://shark_tank/latest"
+):
     model_name = model_name.replace("/", "_")
     os.makedirs(WORKDIR, exist_ok=True)
     model_dir_name = model_name + "_tf"
 
     def gs_download_model():
         gs_command = (
-            'gsutil -o "GSUtil:parallel_process_count=1" cp -r gs://shark_tank/'
-            + shark_default_sha
+            'gsutil -o "GSUtil:parallel_process_count=1" cp -r '
+            + tank_url
             + "/"
             + model_dir_name
             + " "
@@ -227,8 +229,8 @@ def download_tf_model(model_name, tuned=None, shark_default_sha="latest"):
         model_dir = os.path.join(WORKDIR, model_dir_name)
         local_hash = str(np.load(os.path.join(model_dir, "hash.npy")))
         gs_hash = (
-            'gsutil -o "GSUtil:parallel_process_count=1" cp gs://shark_tank/'
-            + shark_default_sha
+            'gsutil -o "GSUtil:parallel_process_count=1" cp '
+            + tank_url
             + "/"
             + model_dir_name
             + "/hash.npy"

--- a/tank/test_models.py
+++ b/tank/test_models.py
@@ -278,8 +278,6 @@ class SharkModuleTest(unittest.TestCase):
                     pytest.xfail(
                         reason="M2: Assert Error & M1: CompilerToolError"
                     )
-        if config["model_name"] == "roberta-base" and device == "cuda":
-            pytest.xfail(reason="https://github.com/nod-ai/SHARK/issues/274")
         if config["model_name"] == "google/rembert":
             pytest.skip(reason="Model too large to convert.")
         if config[

--- a/tank/test_models.py
+++ b/tank/test_models.py
@@ -132,15 +132,18 @@ class SharkModuleTester:
     def create_and_check_module(self, dynamic, device):
         if self.config["framework"] == "tf":
             model, func_name, inputs, golden_out = download_tf_model(
-                self.config["model_name"]
+                self.config["model_name"],
+                tank_url=self.tank_url,
             )
         elif self.config["framework"] == "torch":
             model, func_name, inputs, golden_out = download_torch_model(
-                self.config["model_name"]
+                self.config["model_name"],
+                tank_url=self.tank_url,
             )
         elif self.config["framework"] == "tflite":
             model, func_name, inputs, golden_out = download_tflite_model(
-                model_name=self.config["model_name"]
+                model_name=self.config["model_name"],
+                tank_url=self.tank_url,
             )
         else:
             model, func_name, inputs, golden_out = None, None, None, None
@@ -259,6 +262,7 @@ class SharkModuleTest(unittest.TestCase):
         self.module_tester.tf32 = self.pytestconfig.getoption("tf32")
         self.module_tester.ci = self.pytestconfig.getoption("ci")
         self.module_tester.ci_sha = self.pytestconfig.getoption("ci_sha")
+        self.module_tester.tank_url = self.pytestconfig.getoption("tank_url")
         if (
             config["model_name"] == "facebook/convnext-tiny-224"
             and device == "cuda"


### PR DESCRIPTION
Alternate shark tank URLs must have the same layout past the default URL's SHA (`custom_url/<modelname>/artifacts...`)