### PR TITLE
Wrap module strings in lists to cut down on copying

### DIFF
--- a/shark/shark_benchmark_runner.py
+++ b/shark/shark_benchmark_runner.py
@@ -43,7 +43,7 @@ class SharkBenchmarkRunner(SharkRunner):
     # SharkRunner derived class with Benchmarking capabilities.
     def __init__(
         self,
-        mlir_module: str,
+        mlir_module: list,
         function_name: str = "forward",
         device: str = "none",
         mlir_dialect: str = "linalg",
@@ -65,7 +65,7 @@ class SharkBenchmarkRunner(SharkRunner):
         )
         if self.vmfb_file == None:
             self.vmfb_file = export_iree_module_to_vmfb(
-                mlir_module,
+                mlir_module[0],
                 device,
                 shark_args.repro_dir,
                 self.mlir_dialect,

--- a/shark/shark_inference.py
+++ b/shark/shark_inference.py
@@ -36,8 +36,8 @@ class SharkInference:
 
     Attributes
     ----------
-    mlir_module : str
-        mlir_module represented in string.
+    mlir_module : list
+        mlir_module represented in a list of (one) string.
     function_name : str
         function to execute in the given mlir_module.
     device : str
@@ -63,7 +63,7 @@ class SharkInference:
 
     def __init__(
         self,
-        mlir_module: str,
+        mlir_module: list,
         function_name: str = "forward",
         device: str = "none",
         mlir_dialect: str = "linalg",
@@ -109,7 +109,7 @@ class SharkInference:
         # func_key to get the line which contains the function.
         func_key = "func.func @" + self.function_name
         func_header = None
-        for line in str(self.mlir_module).splitlines():
+        for line in str(self.mlir_module[0]).splitlines():
             if func_key in line:
                 func_header = line
                 break
@@ -148,7 +148,7 @@ class SharkInference:
     # , user may want to save the module with manual names.
     def save_module(self, dir=os.getcwd(), module_name=None, extra_args=[]):
         return export_iree_module_to_vmfb(
-            self.mlir_module,
+            self.mlir_module[0],
             self.device,
             dir,
             self.mlir_dialect,

--- a/shark/shark_runner.py
+++ b/shark/shark_runner.py
@@ -37,8 +37,8 @@ class SharkRunner:
 
     Attributes
     ----------
-    mlir_module : str
-        mlir_module represented in string.
+    mlir_module : list
+        mlir_module represented in a list of (one) string.
     function_name : str
         function to execute in the given mlir_module.
     device : str
@@ -61,7 +61,7 @@ class SharkRunner:
 
     def __init__(
         self,
-        mlir_module: str = "none",
+        mlir_module: list = ["none"],
         function_name: str = "forward",
         device: str = "none",
         mlir_dialect: str = "linalg",
@@ -84,7 +84,7 @@ class SharkRunner:
                 self.iree_compilation_module,
                 self.iree_config,
             ) = get_iree_compiled_module(
-                self.mlir_module,
+                self.mlir_module[0],
                 self.device,
                 self.mlir_dialect,
                 func_name=self.function_name,


### PR DESCRIPTION
I'm still testing this, results so far are inconclusive.