### PR TITLE
Add support for choosing vulkan device

### DIFF
--- a/shark/examples/shark_inference/stable_diffusion/utils.py
+++ b/shark/examples/shark_inference/stable_diffusion/utils.py
@@ -13,7 +13,12 @@ if args.import_mlir:
 
 def _compile_module(shark_module, model_name, extra_args=[]):
     if args.load_vmfb or args.save_vmfb:
-        extended_name = "{}_{}".format(model_name, args.device)
+        device = (
+            args.device
+            if "://" not in args.device
+            else "-".join(args.device.split("://"))
+        )
+        extended_name = "{}_{}".format(model_name, device)
         vmfb_path = os.path.join(os.getcwd(), extended_name + ".vmfb")
         if args.load_vmfb and os.path.isfile(vmfb_path) and not args.save_vmfb:
             print("Loading flatbuffer from {}".format(vmfb_path))

--- a/shark/iree_utils/benchmark_utils.py
+++ b/shark/iree_utils/benchmark_utils.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 import iree.runtime.scripts.iree_benchmark_module as benchmark_module
-from shark.iree_utils._common import run_cmd, IREE_DEVICE_MAP
+from shark.iree_utils._common import run_cmd, iree_device_map
 import numpy as np
 import os
 import re
@@ -69,7 +69,7 @@ def build_benchmark_args(
         # TODO: Replace name of train with actual train fn name.
         fn_name = "train"
     benchmark_cl.append(f"--entry_function={fn_name}")
-    benchmark_cl.append(f"--device={IREE_DEVICE_MAP[device]}")
+    benchmark_cl.append(f"--device={iree_device_map(device)}")
     mlir_input_types = tensor_to_type_str(input_tensors, mlir_dialect)
     for mlir_input in mlir_input_types:
         benchmark_cl.append(f"--function_input={mlir_input}")
@@ -96,7 +96,7 @@ def build_benchmark_args_non_tensor_input(
     # TODO: The function named can be passed as one of the args.
     if function_name:
         benchmark_cl.append(f"--entry_function={function_name}")
-    benchmark_cl.append(f"--device={IREE_DEVICE_MAP[device]}")
+    benchmark_cl.append(f"--device={iree_device_map(device)}")
     for input in inputs:
         benchmark_cl.append(f"--function_input={input}")
     time_extractor = "| awk 'END{{print $2 $3}}'"

--- a/shark/shark_importer.py
+++ b/shark/shark_importer.py
@@ -87,7 +87,6 @@ class SharkImporter:
 
     def _tflite_mlir(self, func_name, save_dir="./shark_tmp/"):
         from iree.compiler import tflite as tflitec
-        from shark.iree_utils._common import IREE_TARGET_MAP
 
         self.mlir_model = tflitec.compile_file(
             self.raw_model_file,  # in tflite, it is a path to .tflite file, not a tflite interpreter

--- a/tank/test_models.py
+++ b/tank/test_models.py
@@ -1,7 +1,7 @@
 from shark.iree_utils._common import (
     check_device_drivers,
     device_driver_info,
-    IREE_DEVICE_MAP,
+    get_supported_device_list,
 )
 from shark.iree_utils.vulkan_utils import get_vulkan_triple_flag
 from parameterized import parameterized
@@ -59,7 +59,7 @@ def get_valid_test_params():
     """
     device_list = [
         device
-        for device in IREE_DEVICE_MAP.keys()
+        for device in get_supported_device_list()
         if not check_device_drivers(device)
     ]
     dynamic_list = (True, False)


### PR DESCRIPTION
use --device flag to choose single vulkan device 
device name should be same as found in `./iree-run-module --list_devices=vulkan`

when choosing a specific device, ensure to provide appropriate `-iree-vulkan-target-triple`