### PR TITLE
Actually print the error message when SharkRunner can't initialize the driver

### DIFF
--- a/shark/shark_runner.py
+++ b/shark/shark_runner.py
@@ -75,7 +75,7 @@ class SharkRunner:
         self.extra_args = extra_args
 
         if check_device_drivers(self.device):
-            device_driver_info(self.device)
+            print(device_driver_info(self.device))
             sys.exit(1)
 
         if compile_vmfb == True:


### PR DESCRIPTION
Right now it would just terminate the process silently