### PR TITLE
Don't do a numpy copy on the results from compiled vm

### DIFF
--- a/shark/examples/shark_inference/stable_diffusion/main.py
+++ b/shark/examples/shark_inference/stable_diffusion/main.py
@@ -159,8 +159,8 @@ if __name__ == "__main__":
     vae_end = time.time()
     end_profiling(profile_device)
     image = torch.from_numpy(image)
-    image = image.detach().cpu().permute(0, 2, 3, 1).numpy()
-    images = (image * 255).round().astype("uint8")
+    image = image.detach().cpu().permute(0, 2, 3, 1) * 255.0
+    images = image.numpy().round().astype("uint8")
     total_end = time.time()
 
     clip_inf_time = (clip_inf_end - clip_inf_start) * 1000

--- a/shark/iree_utils/compile_utils.py
+++ b/shark/iree_utils/compile_utils.py
@@ -343,7 +343,7 @@ def get_results(compiled_vm, input, config, frontend="torch"):
         res = np.array(data, dtype=object)
         return np.copy(res)
     else:
-        return np.copy(np.asarray(result, dtype=result.dtype))
+        return result.to_host()
 
 
 def get_iree_runtime_config(device):


### PR DESCRIPTION
The numpy copy causes a ~1s overhead for VAE on windows.