### PR TITLE
Enable conv nchw-to-nhwc flag by default for most models + minor fixes

### DIFF
--- a/shark/parser.py
+++ b/shark/parser.py
@@ -105,4 +105,11 @@ parser.add_argument(
     help='directory where you want to store dispatch data generated with "--dispatch_benchmarks"',
 )
 
+parser.add_argument(
+    "--enable_conv_transform",
+    default=True,
+    action="store",
+    help="Enables the --iree-flow-enable-conv-nchw-to-nhwc-transform flag.",
+)
+
 shark_args, unknown = parser.parse_known_args()

--- a/tank/model_utils.py
+++ b/tank/model_utils.py
@@ -143,14 +143,14 @@ def get_vision_model(torch_model):
     import torchvision.models as models
 
     vision_models_dict = {
-        "alexnet": models.alexnet(pretrained=True),
-        "resnet18": models.resnet18(pretrained=True),
-        "resnet50": models.resnet50(pretrained=True),
-        "resnet101": models.resnet101(pretrained=True),
-        "squeezenet1_0": models.squeezenet1_0(pretrained=True),
-        "wide_resnet50_2": models.wide_resnet50_2(pretrained=True),
-        "mobilenet_v3_small": models.mobilenet_v3_small(pretrained=True),
-        "mnasnet1_0": models.mnasnet1_0(pretrained=True),
+        "alexnet": models.alexnet(weights="DEFAULT"),
+        "resnet18": models.resnet18(weights="DEFAULT"),
+        "resnet50": models.resnet50(weights="DEFAULT"),
+        "resnet101": models.resnet101(weights="DEFAULT"),
+        "squeezenet1_0": models.squeezenet1_0(weights="DEFAULT"),
+        "wide_resnet50_2": models.wide_resnet50_2(weights="DEFAULT"),
+        "mobilenet_v3_small": models.mobilenet_v3_small(weights="DEFAULT"),
+        "mnasnet1_0": models.mnasnet1_0(weights="DEFAULT"),
     }
     if isinstance(torch_model, str):
         torch_model = vision_models_dict[torch_model]

--- a/tank/test_models.py
+++ b/tank/test_models.py
@@ -127,8 +127,11 @@ class SharkModuleTester:
         self.config = config
 
     def create_and_check_module(self, dynamic, device):
+
         shark_args.local_tank_cache = self.local_tank_cache
         shark_args.update_tank = self.update_tank
+        if self.config["model_name"] in ["alexnet", "resnet18"]:
+            shark_args.enable_conv_transform = False
         model, func_name, inputs, golden_out = download_model(
             self.config["model_name"],
             tank_url=self.tank_url,
@@ -347,7 +350,16 @@ class SharkModuleTest(unittest.TestCase):
             pytest.xfail(
                 reason="Numerics Issues: https://github.com/nod-ai/SHARK/issues/388"
             )
-        if config["model_name"] == "mobilenet_v3_small":
+        if config["model_name"] == "mobilenet_v3_small" and device not in [
+            "cpu"
+        ]:
+            pytest.xfail(
+                reason="Numerics Issues: https://github.com/nod-ai/SHARK/issues/388"
+            )
+        if config["model_name"] == "mnasnet1_0" and device not in [
+            "cpu",
+            "cuda",
+        ]:
             pytest.xfail(
                 reason="Numerics Issues: https://github.com/nod-ai/SHARK/issues/388"
             )


### PR DESCRIPTION
minor fixes:
- enable mobilenet on cpu
- fix deprecated torchvision api usage

adds support for model-specific automatic iree-compile flag assignment via shark_args assignments in pytest
adds `--iree-flow-enable-conv-nchw-to-nhwc-transform` flag by default.