### PR TITLE
Add config stanza for NVIDIA RTX 2080.

### DIFF
--- a/shark/iree_utils/vulkan_utils.py
+++ b/shark/iree_utils/vulkan_utils.py
@@ -58,6 +58,11 @@ def get_vulkan_triple_flag(extra_args=[]):
         print("Found Apple M2 Device. Using m1-moltenvk-macos")
         return "-iree-vulkan-target-triple=m1-moltenvk-macos"
     # Nvidia Targets
+    elif all(x in vulkan_device for x in ("RTX", "2080")):
+        print(
+            f"Found {vulkan_device} Device. Using turing-rtx2080-{system_os}"
+        )
+        return f"-iree-vulkan-target-triple=turing-rtx2080-{system_os}"
     elif all(x in vulkan_device for x in ("A100", "SXM4")):
         print(
             f"Found {vulkan_device} Device. Using ampere-rtx3080-{system_os}"


### PR DESCRIPTION
Just happened to have this card on my Windows machine and verified that the SD demo works on it.

```
Average step time: 144.26142692565918ms/it
Clip Inference Avg time (ms) = (205.001 + 44.000) / 2 = 124.501
VAE Inference time (ms): 281.001

Total image generation time: 7.856997728347778sec
```

I'd love to add an API upstream to derive compiler tuning flags from a host device.