### PR TITLE
[SD][web] Fix performance issues on shark scheduler

### DIFF
--- a/shark/examples/shark_inference/stable_diffusion/opt_params.py
+++ b/shark/examples/shark_inference/stable_diffusion/opt_params.py
@@ -7,13 +7,21 @@ from model_wrappers import (
 )
 from stable_args import args
 from utils import get_shark_model
+from shark.iree_utils.vulkan_utils import get_vulkan_triple_flag
 
 BATCH_SIZE = len(args.prompts)
 if BATCH_SIZE != 1:
     sys.exit("Only batch size 1 is supported.")
 
-if "rdna3" not in args.iree_vulkan_target_triple:
+# use tuned models only in the case of rdna3 cards.
+if not args.iree_vulkan_target_triple:
+    vulkan_triple_flags = get_vulkan_triple_flag()
+    if vulkan_triple_flags and "rdna3" not in vulkan_triple_flags:
+        args.use_tuned = False
+elif "rdna3" not in args.iree_vulkan_target_triple:
     args.use_tuned = False
+if args.use_tuned:
+    print("Using tuned models for rdna3 card")
 
 
 def get_unet():

--- a/web/models/stable_diffusion/cache_objects.py
+++ b/web/models/stable_diffusion/cache_objects.py
@@ -12,8 +12,9 @@ from models.stable_diffusion.stable_args import args
 from models.stable_diffusion.schedulers import (
     SharkEulerDiscreteScheduler,
 )
-from shark.iree_utils.vulkan_utils import get_vulkan_triple_flag
 
+# set iree-runtime flags
+set_iree_runtime_flags()
 
 model_config = {
     "v2": "stabilityai/stable-diffusion-2",
@@ -47,15 +48,6 @@ schedulers["SharkEulerDiscrete"] = SharkEulerDiscreteScheduler.from_pretrained(
     subfolder="scheduler",
 )
 schedulers["SharkEulerDiscrete"].compile()
-
-vulkan_triple_flags = get_vulkan_triple_flag()
-
-# use tuned unet model in case of rdna3 cards.
-if vulkan_triple_flags and "rdna3" in vulkan_triple_flags:
-    args.use_tuned = True
-
-# set iree-runtime flags
-set_iree_runtime_flags()
 
 cache_obj = dict()
 # cache vae, unet and clip.

--- a/web/models/stable_diffusion/opt_params.py
+++ b/web/models/stable_diffusion/opt_params.py
@@ -7,10 +7,22 @@ from models.stable_diffusion.model_wrappers import (
 )
 from models.stable_diffusion.stable_args import args
 from models.stable_diffusion.utils import get_shark_model
+from shark.iree_utils.vulkan_utils import get_vulkan_triple_flag
 
 BATCH_SIZE = len(args.prompts)
 if BATCH_SIZE != 1:
     sys.exit("Only batch size 1 is supported.")
+
+# use tuned models only in the case of rdna3 cards.
+args.use_tuned = False
+if not args.iree_vulkan_target_triple:
+    vulkan_triple_flags = get_vulkan_triple_flag()
+    if vulkan_triple_flags and "rdna3" in vulkan_triple_flags:
+        args.use_tuned = True
+elif "rdna3" in args.iree_vulkan_target_triple:
+    args.use_tuned = True
+if args.use_tuned:
+    print("Using tuned models for rdna3 card")
 
 
 def get_unet():


### PR DESCRIPTION
1. SD web uses tuned models for rdna3 card irrespective of `--use_tuned` flag.
2. Current SD web performance:
    ```Average step time: 52.650580406188965ms/it
    Clip Inference time (ms) = 68.021
    VAE Inference time (ms): 212.207
    Total image generation time: 3.130343198776245sec```

Signed-Off-by: Gaurav Shukla <gaurav@nod-labs.com>