### PR TITLE
[SD] Set model max length 64 as default

### DIFF
--- a/shark/examples/shark_inference/stable_diffusion/stable_args.py
+++ b/shark/examples/shark_inference/stable_diffusion/stable_args.py
@@ -46,8 +46,8 @@ p.add_argument(
 p.add_argument(
     "--max_length",
     type=int,
-    default=77,
-    help="max length of the tokenizer output.",
+    default=64,
+    help="max length of the tokenizer output, options are 64 and 77.",
 )
 
 ##############################################################################
@@ -134,7 +134,7 @@ p.add_argument(
 
 p.add_argument(
     "--use_compiled_scheduler",
-    default=False,
+    default=True,
     action=argparse.BooleanOptionalAction,
     help="use the default scheduler precompiled into the model if available",
 )

--- a/web/models/stable_diffusion/stable_args.py
+++ b/web/models/stable_diffusion/stable_args.py
@@ -46,8 +46,8 @@ p.add_argument(
 p.add_argument(
     "--max_length",
     type=int,
-    default=77,
-    help="max length of the tokenizer output.",
+    default=64,
+    help="max length of the tokenizer output, options are 64 and 77.",
 )
 
 ##############################################################################


### PR DESCRIPTION
Also use this flag `--use_compiled_scheduler` by default