### PR TITLE
Add Anything v3 and AnalogDiffusion variants of SD

### DIFF
--- a/shark/examples/shark_inference/stable_diffusion/README.md
+++ b/shark/examples/shark_inference/stable_diffusion/README.md
@@ -42,3 +42,15 @@ unzip ~/.local/shark_tank/<your unet>/inputs.npz
 
 iree-benchmark-module --module_file=/path/to/output/vmfb --entry_function=forward --function_input=@arr_0.npy --function_input=1xf16 --function_input=@arr_2.npy --function_input=@arr_3.npy --function_input=@arr_4.npy  
 ```
+
+## Using other supported Stable Diffusion variants with SHARK:
+
+Currently we support the following fine-tuned versions of Stable Diffusion:
+- [AnythingV3](https://huggingface.co/Linaqruf/anything-v3.0)
+- [Analog Diffusion](https://huggingface.co/wavymulder/Analog-Diffusion)
+
+use the flag `--variant=` to specify the model to be used.
+
+```shell
+python .\shark\examples\shark_inference\stable_diffusion\main.py --variant=anythingv3 --max_length=77 --prompt="1girl, brown hair, green eyes, colorful, autumn, cumulonimbus clouds, lighting, blue sky, falling leaves, garden"
+```

--- a/shark/examples/shark_inference/stable_diffusion/main.py
+++ b/shark/examples/shark_inference/stable_diffusion/main.py
@@ -50,7 +50,7 @@ if __name__ == "__main__":
     neg_prompt = args.negative_prompts
     height = 512  # default height of Stable Diffusion
     width = 512  # default width of Stable Diffusion
-    if args.version == "v2.1":
+    if args.version == "v2.1" and args.variant == "stablediffusion":
         height = 768
         width = 768
 
@@ -71,9 +71,9 @@ if __name__ == "__main__":
         sys.exit("prompts and negative prompts must be of same length")
 
     set_iree_runtime_flags()
+    clip = get_clip()
     unet = get_unet()
     vae = get_vae()
-    clip = get_clip()
     if args.dump_isa:
         dump_isas(args.dispatch_benchmarks_dir)
 

--- a/shark/examples/shark_inference/stable_diffusion/model_wrappers.py
+++ b/shark/examples/shark_inference/stable_diffusion/model_wrappers.py
@@ -60,7 +60,7 @@ model_input = {
 model_revision = {
     "stablediffusion": "fp16" if args.precision == "fp16" else "main",
     "anythingv3": "diffusers",
-    "analogdiffusion" : "main",
+    "analogdiffusion": "main",
 }
 
 
@@ -83,6 +83,7 @@ def get_clip_mlir(model_name="clip_text", extra_args=[]):
         )
     else:
         raise (f"{args.variant} not yet added")
+
     class CLIPText(torch.nn.Module):
         def __init__(self):
             super().__init__()

--- a/shark/examples/shark_inference/stable_diffusion/model_wrappers.py
+++ b/shark/examples/shark_inference/stable_diffusion/model_wrappers.py
@@ -18,6 +18,7 @@ model_variant = {
     "anythingv3": "Linaqruf/anything-v3.0",
     "dreamlike": "dreamlike-art/dreamlike-diffusion-1.0",
     "openjourney": "prompthero/openjourney",
+    "analogdiffusion": "wavymulder/Analog-Diffusion",
 }
 
 model_input = {
@@ -130,15 +131,16 @@ def get_vae_mlir(model_name="vae", extra_args=[]):
         else:
             inputs = model_input[args.version]["vae"]
     elif args.variant in ["anythingv3", "analogdiffusion"]:
+        if args.precision == "fp16":
             vae = vae.half().cuda()
             inputs = tuple(
-                [
-                    inputs.half().cuda()
-                    for inputs in model_input["v1.4"]["vae"]
-                ]
+                [inputs.half().cuda() for inputs in model_input["v1.4"]["vae"]]
             )
+        else:
+            inputs = model_input["v1.4"]["vae"]
     else:
         raise (f"{args.variant} not yet added")
+
     shark_vae = compile_through_fx(
         vae,
         inputs,
@@ -197,7 +199,6 @@ def get_unet_mlir(model_name="unet", extra_args=[]):
             )
         else:
             inputs = model_input["v1.4"]["unet"]
-
     else:
         raise (f"{args.variant} is not yet added")
     shark_unet = compile_through_fx(

--- a/shark/examples/shark_inference/stable_diffusion/model_wrappers.py
+++ b/shark/examples/shark_inference/stable_diffusion/model_wrappers.py
@@ -12,6 +12,8 @@ model_config = {
 
 # clip has 2 variants of max length 77 or 64.
 model_clip_max_length = 64 if args.max_length == 64 else 77
+if args.variant != "stablediffusion":
+    model_clip_max_length = 77
 
 model_variant = {
     "stablediffusion": "SD",

--- a/shark/examples/shark_inference/stable_diffusion/opt_params.py
+++ b/shark/examples/shark_inference/stable_diffusion/opt_params.py
@@ -32,65 +32,85 @@ def get_unet():
     # Disable bindings fusion to work with moltenVK.
     if sys.platform == "darwin":
         iree_flags.append("-iree-stream-fuse-binding=false")
-    # Tuned model is present for `fp16` precision.
-    if args.precision == "fp16":
-        if args.use_tuned:
-            bucket = "gs://shark_tank/vivian"
-            if args.version == "v1.4":
-                model_name = "unet_1dec_fp16_tuned"
-            if args.version == "v2.1base":
-                if args.max_length == 64:
-                    model_name = "unet_19dec_v2p1base_fp16_64_tuned"
-                else:
-                    model_name = "unet2base_8dec_fp16_tuned_v2"
-            return get_shark_model(bucket, model_name, iree_flags)
-        else:
+
+    if args.variant == "stablediffusion":
+        # Tuned model is present for `fp16` precision.
+        if args.precision == "fp16":
+            if args.use_tuned:
+                bucket = "gs://shark_tank/vivian"
+                if args.version == "v1.4":
+                    model_name = "unet_1dec_fp16_tuned"
+                if args.version == "v2.1base":
+                    if args.max_length == 64:
+                        model_name = "unet_19dec_v2p1base_fp16_64_tuned"
+                    else:
+                        model_name = "unet2base_8dec_fp16_tuned_v2"
+                return get_shark_model(bucket, model_name, iree_flags)
+            else:
+                bucket = "gs://shark_tank/stable_diffusion"
+                model_name = "unet_8dec_fp16"
+                if args.version == "v2.1base":
+                    if args.max_length == 64:
+                        model_name = "unet_19dec_v2p1base_fp16_64"
+                    else:
+                        model_name = "unet2base_8dec_fp16"
+                if args.version == "v2.1":
+                    model_name = "unet2_14dec_fp16"
+                iree_flags += [
+                    "--iree-flow-enable-padding-linalg-ops",
+                    "--iree-flow-linalg-ops-padding-size=32",
+                    "--iree-flow-enable-conv-img2col-transform",
+                ]
+                if args.import_mlir:
+                    return get_unet_mlir(model_name, iree_flags)
+                return get_shark_model(bucket, model_name, iree_flags)
+
+        # Tuned model is not present for `fp32` case.
+        if args.precision == "fp32":
             bucket = "gs://shark_tank/stable_diffusion"
-            model_name = "unet_8dec_fp16"
-            if args.version == "v2.1base":
-                if args.max_length == 64:
-                    model_name = "unet_19dec_v2p1base_fp16_64"
-                else:
-                    model_name = "unet2base_8dec_fp16"
-            if args.version == "v2.1":
-                model_name = "unet2_14dec_fp16"
+            model_name = "unet_1dec_fp32"
             iree_flags += [
+                "--iree-flow-enable-conv-nchw-to-nhwc-transform",
                 "--iree-flow-enable-padding-linalg-ops",
-                "--iree-flow-linalg-ops-padding-size=32",
-                "--iree-flow-enable-conv-img2col-transform",
+                "--iree-flow-linalg-ops-padding-size=16",
             ]
             if args.import_mlir:
                 return get_unet_mlir(model_name, iree_flags)
             return get_shark_model(bucket, model_name, iree_flags)
 
-    # Tuned model is not present for `fp32` case.
-    if args.precision == "fp32":
-        bucket = "gs://shark_tank/stable_diffusion"
-        model_name = "unet_1dec_fp32"
-        iree_flags += [
-            "--iree-flow-enable-conv-nchw-to-nhwc-transform",
-            "--iree-flow-enable-padding-linalg-ops",
-            "--iree-flow-linalg-ops-padding-size=16",
-        ]
-        if args.import_mlir:
-            return get_unet_mlir(model_name, iree_flags)
-        return get_shark_model(bucket, model_name, iree_flags)
+        if args.precision == "int8":
+            bucket = "gs://shark_tank/prashant_nod"
+            model_name = "unet_int8"
+            iree_flags += [
+                "--iree-flow-enable-padding-linalg-ops",
+                "--iree-flow-linalg-ops-padding-size=32",
+            ]
+            sys.exit("int8 model is currently in maintenance.")
+            # # TODO: Pass iree_flags to the exported model.
+            # if args.import_mlir:
+            # sys.exit(
+            # "--import_mlir is not supported for the int8 model, try --no-import_mlir flag."
+            # )
+            # return get_shark_model(bucket, model_name, iree_flags)
 
-    if args.precision == "int8":
-        bucket = "gs://shark_tank/prashant_nod"
-        model_name = "unet_int8"
+    else:
         iree_flags += [
             "--iree-flow-enable-padding-linalg-ops",
             "--iree-flow-linalg-ops-padding-size=32",
+            "--iree-flow-enable-conv-img2col-transform",
         ]
-        sys.exit("int8 model is currently in maintenance.")
-        # # TODO: Pass iree_flags to the exported model.
-        # if args.import_mlir:
-        # sys.exit(
-        # "--import_mlir is not supported for the int8 model, try --no-import_mlir flag."
-        # )
-        # return get_shark_model(bucket, model_name, iree_flags)
+        if args.variant == "anythingv3":
+            bucket = "gs://shark_tank/sd_anythingv3"
+            model_name = f"av3_unet_19dec_{args.precision}"
+        elif args.variant == "analogdiffusion":
+            bucket = "gs://shark_tank/sd_analog_diffusion"
+            model_name = f"ad_unet_19dec_{args.precision}"
+        else :
+            sys.exit(f"{args.variant} variant of SD is currently unsupported")
 
+        if args.import_mlir:
+            return get_unet_mlir(model_name, iree_flags)
+        return get_shark_model(bucket, model_name, iree_flags)
 
 def get_vae():
     iree_flags = []
@@ -101,46 +121,79 @@ def get_vae():
     # Disable bindings fusion to work with moltenVK.
     if sys.platform == "darwin":
         iree_flags.append("-iree-stream-fuse-binding=false")
-    if args.precision in ["fp16", "int8"]:
-        if args.use_tuned:
-            bucket = "gs://shark_tank/vivian"
-            if args.version == "v2.1base":
-                model_name = "vae2base_19dec_fp16_tuned"
-            iree_flags += [
-                "--iree-flow-enable-padding-linalg-ops",
-                "--iree-flow-linalg-ops-padding-size=32",
-                "--iree-flow-enable-conv-img2col-transform",
-                "--iree-flow-enable-conv-winograd-transform",
-            ]
-            return get_shark_model(bucket, model_name, iree_flags)
-        else:
+
+    if args.variant == "stablediffusion":
+        if args.precision in ["fp16", "int8"]:
+            if args.use_tuned:
+                bucket = "gs://shark_tank/vivian"
+                if args.version == "v2.1base":
+                    model_name = "vae2base_19dec_fp16_tuned"
+                iree_flags += [
+                    "--iree-flow-enable-padding-linalg-ops",
+                    "--iree-flow-linalg-ops-padding-size=32",
+                    "--iree-flow-enable-conv-img2col-transform",
+                    "--iree-flow-enable-conv-winograd-transform",
+                ]
+                return get_shark_model(bucket, model_name, iree_flags)
+            else:
+                bucket = "gs://shark_tank/stable_diffusion"
+                model_name = "vae_19dec_fp16"
+                if args.version == "v2.1base":
+                    model_name = "vae2base_19dec_fp16"
+                if args.version == "v2.1":
+                    model_name = "vae2_19dec_fp16"
+                iree_flags += [
+                    "--iree-flow-enable-padding-linalg-ops",
+                    "--iree-flow-linalg-ops-padding-size=32",
+                    "--iree-flow-enable-conv-img2col-transform",
+                ]
+                if args.import_mlir:
+                    return get_vae_mlir(model_name, iree_flags)
+                return get_shark_model(bucket, model_name, iree_flags)
+
+        if args.precision == "fp32":
             bucket = "gs://shark_tank/stable_diffusion"
-            model_name = "vae_19dec_fp16"
-            if args.version == "v2.1base":
-                model_name = "vae2base_19dec_fp16"
-            if args.version == "v2.1":
-                model_name = "vae2_19dec_fp16"
+            model_name = "vae_1dec_fp32"
             iree_flags += [
+                "--iree-flow-enable-conv-nchw-to-nhwc-transform",
                 "--iree-flow-enable-padding-linalg-ops",
-                "--iree-flow-linalg-ops-padding-size=32",
-                "--iree-flow-enable-conv-img2col-transform",
+                "--iree-flow-linalg-ops-padding-size=16",
             ]
             if args.import_mlir:
                 return get_vae_mlir(model_name, iree_flags)
             return get_shark_model(bucket, model_name, iree_flags)
 
-    if args.precision == "fp32":
-        bucket = "gs://shark_tank/stable_diffusion"
-        model_name = "vae_1dec_fp32"
+    else:
         iree_flags += [
-            "--iree-flow-enable-conv-nchw-to-nhwc-transform",
             "--iree-flow-enable-padding-linalg-ops",
-            "--iree-flow-linalg-ops-padding-size=16",
         ]
-        if args.import_mlir:
-            return get_vae_mlir(model_name, iree_flags)
-        return get_shark_model(bucket, model_name, iree_flags)
+        if args.precision == 'fp16':
+            iree_flags += [
+                "--iree-flow-linalg-ops-padding-size=16",
+                "--iree-flow-enable-conv-img2col-transform",
+            ]
+        elif args.precision == 'fp32':
+            iree_flags += [
+                "--iree-flow-linalg-ops-padding-size=32",
+                "--iree-flow-enable-conv-nchw-to-nhwc-transform",
+            ]
+        else:
+            sys.exit("int8 precision is currently in not supported.")
 
+        if args.variant == "anythingv3":
+            bucket = "gs://shark_tank/sd_anythingv3"
+            model_name = f"av3_vae_19dec_{args.precision}"
+
+        elif args.variant == "analogdiffusion":
+            bucket = "gs://shark_tank/sd_analog_diffusion"
+            model_name = f"ad_vae_19dec_{args.precision}"
+
+        else :
+            sys.exit(f"{args.variant} variant of SD is currently unsupported")
+
+        if args.import_mlir:
+            return get_unet_mlir(model_name, iree_flags)
+        return get_shark_model(bucket, model_name, iree_flags)
 
 def get_clip():
     iree_flags = []
@@ -151,19 +204,39 @@ def get_clip():
     # Disable bindings fusion to work with moltenVK.
     if sys.platform == "darwin":
         iree_flags.append("-iree-stream-fuse-binding=false")
-    bucket = "gs://shark_tank/stable_diffusion"
-    model_name = "clip_18dec_fp32"
-    if args.version == "v2.1base":
-        if args.max_length == 64:
-            model_name = "clip_19dec_v2p1base_fp32_64"
-        else:
-            model_name = "clip2base_18dec_fp32"
-    if args.version == "v2.1":
-        model_name = "clip2_18dec_fp32"
-    iree_flags += [
-        "--iree-flow-linalg-ops-padding-size=16",
-        "--iree-flow-enable-padding-linalg-ops",
-    ]
+
+    if args.variant == "stablediffusion":
+        bucket = "gs://shark_tank/stable_diffusion"
+        model_name = "clip_18dec_fp32"
+        if args.version == "v2.1base":
+            if args.max_length == 64:
+                model_name = "clip_19dec_v2p1base_fp32_64"
+            else:
+                model_name = "clip2base_18dec_fp32"
+        if args.version == "v2.1":
+            model_name = "clip2_18dec_fp32"
+        iree_flags += [
+            "--iree-flow-linalg-ops-padding-size=16",
+            "--iree-flow-enable-padding-linalg-ops",
+        ]
+        if args.import_mlir:
+            return get_clip_mlir(model_name, iree_flags)
+        return get_shark_model(bucket, model_name, iree_flags)
+
+    if args.variant == "anythingv3":
+        bucket = "gs://shark_tank/sd_anythingv3"
+        model_name = "av3_clip_19dec_fp32"
+    elif args.variant == "analogdiffusion":
+        bucket = "gs://shark_tank/sd_analog_diffusion"
+        model_name = "ad_clip_19dec_fp32"
+        iree_flags += [
+            "--iree-flow-enable-padding-linalg-ops",
+            "--iree-flow-linalg-ops-padding-size=16",
+            "--iree-flow-enable-conv-img2col-transform",
+        ]
+    else :
+        sys.exit(f"{args.variant} variant of SD is currently unsupported")
+
     if args.import_mlir:
-        return get_clip_mlir(model_name, iree_flags)
+        return get_unet_mlir(model_name, iree_flags)
     return get_shark_model(bucket, model_name, iree_flags)

--- a/shark/examples/shark_inference/stable_diffusion/opt_params.py
+++ b/shark/examples/shark_inference/stable_diffusion/opt_params.py
@@ -105,12 +105,13 @@ def get_unet():
         elif args.variant == "analogdiffusion":
             bucket = "gs://shark_tank/sd_analog_diffusion"
             model_name = f"ad_unet_19dec_{args.precision}"
-        else :
+        else:
             sys.exit(f"{args.variant} variant of SD is currently unsupported")
 
         if args.import_mlir:
             return get_unet_mlir(model_name, iree_flags)
         return get_shark_model(bucket, model_name, iree_flags)
+
 
 def get_vae():
     iree_flags = []
@@ -167,12 +168,12 @@ def get_vae():
         iree_flags += [
             "--iree-flow-enable-padding-linalg-ops",
         ]
-        if args.precision == 'fp16':
+        if args.precision == "fp16":
             iree_flags += [
                 "--iree-flow-linalg-ops-padding-size=16",
                 "--iree-flow-enable-conv-img2col-transform",
             ]
-        elif args.precision == 'fp32':
+        elif args.precision == "fp32":
             iree_flags += [
                 "--iree-flow-linalg-ops-padding-size=32",
                 "--iree-flow-enable-conv-nchw-to-nhwc-transform",
@@ -188,12 +189,13 @@ def get_vae():
             bucket = "gs://shark_tank/sd_analog_diffusion"
             model_name = f"ad_vae_19dec_{args.precision}"
 
-        else :
+        else:
             sys.exit(f"{args.variant} variant of SD is currently unsupported")
 
         if args.import_mlir:
             return get_unet_mlir(model_name, iree_flags)
         return get_shark_model(bucket, model_name, iree_flags)
+
 
 def get_clip():
     iree_flags = []
@@ -234,7 +236,7 @@ def get_clip():
             "--iree-flow-linalg-ops-padding-size=16",
             "--iree-flow-enable-conv-img2col-transform",
         ]
-    else :
+    else:
         sys.exit(f"{args.variant} variant of SD is currently unsupported")
 
     if args.import_mlir:

--- a/shark/examples/shark_inference/stable_diffusion/stable_args.py
+++ b/shark/examples/shark_inference/stable_diffusion/stable_args.py
@@ -97,6 +97,11 @@ p.add_argument(
     help="Download and use the tuned version of the model if available",
 )
 
+p.add_argument(
+    "--variant",
+    default="stablediffusion",
+    help="We now support multiple vairants of SD finetuned for different dataset. you can use the following anythingv3, ...",  # TODO add more once supported
+)
 ##############################################################################
 ### IREE - Vulkan supported flags
 ##############################################################################


### PR DESCRIPTION
This PR adds support for 2 new variants of SD, which can be chosen using the `variant` flag in cli as follows:
- `--variant=<anythingv3 / analogdiffusion>`
- `version` flag is not required as we are only supporting the default versions of SD variants.
- the models in the tank currently work with max prompt length 77
