### PR TITLE
Add support for RX480

### DIFF
--- a/shark/iree_utils/vulkan_utils.py
+++ b/shark/iree_utils/vulkan_utils.py
@@ -88,6 +88,8 @@ def get_vulkan_target_triple(device_name):
     # Amd Targets
     elif all(x in device_name for x in ("AMD", "7900")):
         triple = f"rdna3-7900-{system_os}"
+    elif all(x in device_name for x in ("AMD", "480")):
+        triple = f"gcn4-480-{system_os}"
     elif any(x in device_name for x in ("AMD", "Radeon")):
         triple = f"rdna2-unknown-{system_os}"
     else:


### PR DESCRIPTION
This is failing as per [this](https://github.com/nod-ai/SHARK-Runtime/pull/30) with the following message:

```
Using target triple gcn4-480-linux
Traceback (most recent call last):
  File "/mnt/storage/git/SHARK/shark/examples/shark_inference/stable_diffusion/main.py", line 104, in <module>
    unet = get_unet()
  File "/mnt/storage/git/SHARK/shark/examples/shark_inference/stable_diffusion/opt_params.py", line 72, in get_unet
    return get_shark_model(bucket, model_name, iree_flags)
  File "/mnt/storage/git/SHARK/shark/examples/shark_inference/stable_diffusion/utils.py", line 58, in get_shark_model
    return _compile_module(shark_module, model_name, extra_args)
  File "/mnt/storage/git/SHARK/shark/examples/shark_inference/stable_diffusion/utils.py", line 33, in _compile_module
    path = shark_module.save_module(
  File "/mnt/storage/git/SHARK/shark/shark_inference.py", line 188, in save_module
    return export_iree_module_to_vmfb(
  File "/mnt/storage/git/SHARK/shark/iree_utils/compile_utils.py", line 328, in export_iree_module_to_vmfb
    flatbuffer_blob = compile_module_to_flatbuffer(
  File "/mnt/storage/git/SHARK/shark/iree_utils/compile_utils.py", line 271, in compile_module_to_flatbuffer
    flatbuffer_blob = ireec.compile_str(
  File "/home/gap/git/SHARK-Runtime/build/compiler/bindings/python/iree/compiler/tools/core.py", line 278, in compile_str
    result = invoke_immediate(cl, immediate_input=input_bytes)
  File "/home/gap/git/SHARK-Runtime/build/compiler/bindings/python/iree/compiler/tools/binaries.py", line 196, in invoke_immediate
    raise CompilerToolError(process)
iree.compiler.tools.binaries.CompilerToolError: Error invoking IREE compiler tool iree-compile
Diagnostics:
<stdin>:822:11: error: failed to legalize operation 'memref.load'
    %19 = linalg.generic {indexing_maps = [#map5, #map4, #map5], iterator_types = ["parallel", "parallel"]} ins(%18, %cst_2 : tensor<2x160xf32>, tensor<i64>) outs(%17 : tensor<2x160xf32>) {
          ^
<stdin>:28:3: note: called from
  func.func @forward(%arg0: tensor<1x4x64x64xf16>, %arg1: tensor<1xf16>, %arg2: tensor<2x64x1024xf16>, %arg3: tensor<f32>) -> tensor<1x4x64x64xf16> {
  ^
<stdin>:822:11: error: Failures have been detected while processing an MLIR pass pipeline
    %19 = linalg.generic {indexing_maps = [#map5, #map4, #map5], iterator_types = ["parallel", "parallel"]} ins(%18, %cst_2 : tensor<2x160xf32>, tensor<i64>) outs(%17 : tensor<2x160xf32>) {
          ^
<stdin>:28:3: note: called from
  func.func @forward(%arg0: tensor<1x4x64x64xf16>, %arg1: tensor<1xf16>, %arg2: tensor<2x64x1024xf16>, %arg3: tensor<f32>) -> tensor<1x4x64x64xf16> {
  ^
<stdin>:822:11: note: Pipeline failed while executing [`mlir::iree_compiler::IREE::HAL::TranslateExecutablesPass` on 'hal.executable' operation: @forward_dispatch_0, `mlir::iree_compiler::IREE::HAL::TranslateExecutablesPass` on 'hal.executable' operation: @forward_dispatch_2, `mlir::iree_compiler::IREE::HAL::TranslateExecutablesPass` on 'hal.executable' operation: @forward_dispatch_3, `mlir::iree_compiler::IREE::HAL::TranslateExecutablesPass` on 'hal.executable' operation: @forward_dispatch_1, `mlir::iree_compiler::IREE::HAL::TranslateTargetExecutableVariantsPass` on 'hal.executable.variant' operation: @vulkan_spirv_fb, `mlir::iree_compiler::IREE::HAL::TranslateTargetExecutableVariantsPass` on 'hal.executable.variant' operation: @vulkan_spirv_fb, `mlir::iree_compiler::IREE::HAL::TranslateTargetExecutableVariantsPass` on 'hal.executable.variant' operation: @vulkan_spirv_fb, `mlir::iree_compiler::IREE::HAL::TranslateTargetExecutableVariantsPass` on 'hal.executable.variant' operation: @vulkan_spirv_fb, `SPIRVLowerExecutableTarget` on 'hal.executable.variant' operation: @vulkan_spirv_fb, `SPIRVLowerExecutableTarget` on 'hal.executable.variant' operation: @vulkan_spirv_fb, `SPIRVVectorize` on 'func.func' operation: @forward_dispatch_1_generic_320, `SPIRVVectorize` on 'func.func' operation: @forward_dispatch_2_generic_320, `ConvertToSPIRV` on 'builtin.module' operation, `ConvertToSPIRV` on 'builtin.module' operation]: reproducer generated at `iree-tmp/core-reproducer.mlir`
    %19 = linalg.generic {indexing_maps = [#map5, #map4, #map5], iterator_types = ["parallel", "parallel"]} ins(%18, %cst_2 : tensor<2x160xf32>, tensor<i64>) outs(%17 : tensor<2x160xf32>) {
          ^
<stdin>:822:11: error: failed to run translation of source executable to target executable for backend #hal.executable.target<"vulkan", "vulkan-spirv-fb", {spirv.target_env = #spirv.target_env<#spirv.vce<v1.6, [Shader, Float64, Int64, Int8, StorageBuffer16BitAccess, StorageUniform16, StorageBuffer8BitAccess, UniformAndStorageBuffer8BitAccess, GroupNonUniform, GroupNonUniformVote, GroupNonUniformArithmetic, GroupNonUniformBallot, GroupNonUniformShuffle, GroupNonUniformShuffleRelative, GroupNonUniformClustered, GroupNonUniformQuad, VariablePointers, VariablePointersStorageBuffer], [SPV_KHR_16bit_storage, SPV_KHR_8bit_storage, SPV_KHR_storage_buffer_storage_class, SPV_KHR_variable_pointers]>, api=Vulkan, AMD:DiscreteGPU, #spirv.resource_limits<max_compute_shared_memory_size = 65536, max_compute_workgroup_invocations = 1024, max_compute_workgroup_size = [1024, 1024, 1024], subgroup_size = 64, min_subgroup_size = 32, max_subgroup_size = 64, cooperative_matrix_properties_nv = []>>}>
    %19 = linalg.generic {indexing_maps = [#map5, #map4, #map5], iterator_types = ["parallel", "parallel"]} ins(%18, %cst_2 : tensor<2x160xf32>, tensor<i64>) outs(%17 : tensor<2x160xf32>) {
          ^
<stdin>:28:3: note: called from
  func.func @forward(%arg0: tensor<1x4x64x64xf16>, %arg1: tensor<1xf16>, %arg2: tensor<2x64x1024xf16>, %arg3: tensor<f32>) -> tensor<1x4x64x64xf16> {
  ^
<stdin>:822:11: error: failed to serialize executables
    %19 = linalg.generic {indexing_maps = [#map5, #map4, #map5], iterator_types = ["parallel", "parallel"]} ins(%18, %cst_2 : tensor<2x160xf32>, tensor<i64>) outs(%17 : tensor<2x160xf32>) {
          ^
<stdin>:28:3: note: called from
  func.func @forward(%arg0: tensor<1x4x64x64xf16>, %arg1: tensor<1xf16>, %arg2: tensor<2x64x1024xf16>, %arg3: tensor<f32>) -> tensor<1x4x64x64xf16> {
  ^


Invoked with:
 iree-compile /home/gap/git/SHARK-Runtime/build/compiler/bindings/python/iree/compiler/tools/../_mlir_libs/iree-compile - --iree-input-type=none --iree-vm-bytecode-module-output-format=flatbuffer-binary --iree-hal-target-backends=vulkan --iree-llvm-embedded-linker-path=/home/gap/git/SHARK-Runtime/build/compiler/bindings/python/iree/compiler/tools/../_mlir_libs/iree-lld --mlir-print-debuginfo --mlir-print-op-on-diagnostic=false --mlir-pass-pipeline-crash-reproducer=iree-tmp/core-reproducer.mlir --iree-llvm-target-cpu-features=host --iree-stream-resource-index-bits=64 --iree-vm-target-index-bits=64 --iree-util-zero-fill-elided-attrs -iree-vulkan-target-triple=gcn4-480-linux --iree-flow-enable-padding-linalg-ops --iree-flow-linalg-ops-padding-size=32 --iree-flow-enable-conv-img2col-transform
```