### PR TITLE
SD - Command-line - CKPT update feature

### DIFF
--- a/shark/examples/shark_inference/stable_diffusion/README.md
+++ b/shark/examples/shark_inference/stable_diffusion/README.md
@@ -54,3 +54,15 @@ use the flag `--variant=` to specify the model to be used.
 ```shell
 python .\shark\examples\shark_inference\stable_diffusion\main.py --variant=anythingv3 --max_length=77 --prompt="1girl, brown hair, green eyes, colorful, autumn, cumulonimbus clouds, lighting, blue sky, falling leaves, garden"
 ```
+
+## Using custom checkpoints for a specific version of a model:
+
+* To try this feature you need to build [torch-mlir](https://github.com/llvm/torch-mlir/tree/cuda_f16).
+* Also build [iree](https://github.com/nod-ai/SHARK-Runtime/tree/iree_temp_fix_hal_fence).
+* To test the replacement of weight resources you may download [unet-checkpoint](https://huggingface.co/CompVis/stable-diffusion-v1-4/resolve/main/unet/diffusion_pytorch_model.bin) and provide its path to `--unet_checkpoint` command-line argument.
+```shell
+python3.10 shark/examples/shark_inference/stable_diffusion/main.py --precision=fp32 --device=cuda --prompt="tajmahal, oil on canvas, sunflowers, 4k, uhd" --max_length=77 --version="v1_4" --unet_checkpoint=<path to unet's checkpoint file>
+```
+* To monitor checkpoint updates use `--show_checkpoint_update` flag - observe the run printing CURRENT and NEW values, and then printing the CURRENT values after the updation. One may change specific tensor values of the CKPT and see that getting updated.
+* Similarly one can use `--clip_checkpoint` and `--vae_checkpoint` command-line arguments to use custom checkpoint weights for the individual models with specific config like the one shown for unet in the example.
+* NOTE: Currently this feature hasn't been rolled out for tuned models.

--- a/shark/examples/shark_inference/stable_diffusion/opt_params.py
+++ b/shark/examples/shark_inference/stable_diffusion/opt_params.py
@@ -100,7 +100,9 @@ def get_vae():
     if args.vae_checkpoint != "" and not args.use_tuned:
         vae_ts = None
         if args.use_base_vae:
-            vae_ts = get_base_vae_mlir(model_name, iree_flags, get_ts_graph=True)
+            vae_ts = get_base_vae_mlir(
+                model_name, iree_flags, get_ts_graph=True
+            )
         else:
             vae_ts = get_vae_mlir(model_name, iree_flags, get_ts_graph=True)
         vae_model = update_checkpoint(vae_model, vae_ts)

--- a/shark/examples/shark_inference/stable_diffusion/stable_args.py
+++ b/shark/examples/shark_inference/stable_diffusion/stable_args.py
@@ -239,6 +239,13 @@ p.add_argument(
     help="flag to clear all mlir and vmfb from common locations. Recompiling will take several minutes",
 )
 
+p.add_argument(
+    "--show_checkpoint_update",
+    default=False,
+    action=argparse.BooleanOptionalAction,
+    help="flag for hiding the details of weight update for each model",
+)
+
 ##############################################################################
 ### Web UI flags
 ##############################################################################

--- a/shark/examples/shark_inference/stable_diffusion/stable_args.py
+++ b/shark/examples/shark_inference/stable_diffusion/stable_args.py
@@ -123,6 +123,27 @@ p.add_argument(
     help="other supported schedulers are [PNDM, DDIM, LMSDiscrete, EulerDiscrete, DPMSolverMultistep]",
 )
 
+p.add_argument(
+    "--unet_checkpoint",
+    type=str,
+    default="",
+    help="Path to checpoint file (.ckpt/.pth/.bin) for unet of particular 'version'",
+)
+
+p.add_argument(
+    "--clip_checkpoint",
+    type=str,
+    default="",
+    help="Path to checpoint file (.ckpt/.pth/.bin) for clip of particular 'version'",
+)
+
+p.add_argument(
+    "--vae_checkpoint",
+    type=str,
+    default="",
+    help="Path to checpoint file (.ckpt/.pth/.bin) for vae of particular 'version' and of non-base vae by default",
+)
+
 ##############################################################################
 ### IREE - Vulkan supported flags
 ##############################################################################

--- a/shark/examples/shark_inference/stable_diffusion/utils.py
+++ b/shark/examples/shark_inference/stable_diffusion/utils.py
@@ -59,9 +59,13 @@ def get_shark_model(tank_url, model_name, extra_args=[]):
 
 
 # Converts the torch-module into a shark_module.
-def compile_through_fx(model, inputs, model_name, extra_args=[], get_ts_graph=False):
+def compile_through_fx(
+    model, inputs, model_name, extra_args=[], get_ts_graph=False
+):
 
-    mlir_module, func_name = import_with_fx(model, inputs, get_ts_graph=get_ts_graph)
+    mlir_module, func_name = import_with_fx(
+        model, inputs, get_ts_graph=get_ts_graph
+    )
     if get_ts_graph:
         return mlir_module
 
@@ -232,8 +236,10 @@ def get_available_devices():
     available_devices.append("cpu")
     return available_devices
 
+
 def get_vmfb(model_name, extra_args=[]):
     import os
+
     device = (
         args.device
         if "://" not in args.device
@@ -243,11 +249,12 @@ def get_vmfb(model_name, extra_args=[]):
     vmfb_path = os.path.join(os.getcwd(), extended_name + ".vmfb")
     shark_model = None
     import os
+
     if os.path.isfile(vmfb_path):
         shark_model = SharkInference("", device=device)
         shark_model.load_module(vmfb_path, extra_args=extra_args)
     return shark_model
-    
+
 
 def update_checkpoint(CompiledModule, ts_g):
     def debug_print(statement):
@@ -255,7 +262,10 @@ def update_checkpoint(CompiledModule, ts_g):
             print(statement)
 
     import numpy as np
-    debug_print("Fetched TS graph of the PyTorch model and will extract the state_dict")
+
+    debug_print(
+        "Fetched TS graph of the PyTorch model and will extract the state_dict"
+    )
     new_ckpt_from_ts = ts_g.state_dict()
     debug_print("UPDATE the CURRENT weight's value with the NEW one.")
     for func_name in CompiledModule.get_functions_in_module():
@@ -273,7 +283,9 @@ def update_checkpoint(CompiledModule, ts_g):
                 # updating `result` with `new_ckpt_from_ts[param_name]` tensor.
                 assert result.shape == new_ckpt_from_ts[param_name].shape
             else:
-                result = CompiledModule(func_name, (new_ckpt_from_ts[param_name].detach().cpu(),))
+                result = CompiledModule(
+                    func_name, (new_ckpt_from_ts[param_name].detach().cpu(),)
+                )
                 debug_print("UPDATED : " + str(param_name))
 
     debug_print("----------UPDATION COMPLETE----------")

--- a/shark/examples/shark_inference/stable_diffusion/utils.py
+++ b/shark/examples/shark_inference/stable_diffusion/utils.py
@@ -270,7 +270,7 @@ def update_checkpoint(CompiledModule, ts_g):
                 assert result.shape == new_ckpt_from_ts[param_name].shape
             else:
                 print("UPDATING")
-                result = CompiledModule(func_name, (new_ckpt_from_ts[param_name],))
+                result = CompiledModule(func_name, (new_ckpt_from_ts[param_name].detach().cpu(),))
 
     print("----------UPDATION COMPLETE----------")
     for func_name in CompiledModule.get_functions_in_module():

--- a/shark/examples/shark_inference/stable_diffusion/utils.py
+++ b/shark/examples/shark_inference/stable_diffusion/utils.py
@@ -265,6 +265,9 @@ def update_checkpoint(CompiledModule, ts_g):
                 print(result)
                 print("===NEW===")
                 print(new_ckpt_from_ts[param_name])
+                # We add an assert here because the next invocation will end up
+                # updating `result` with `new_ckpt_from_ts[param_name]` tensor.
+                assert result.shape == new_ckpt_from_ts[param_name].shape
             else:
                 print("UPDATING")
                 result = CompiledModule(func_name, (new_ckpt_from_ts[param_name],))

--- a/shark/shark_importer.py
+++ b/shark/shark_importer.py
@@ -289,7 +289,7 @@ def import_with_fx(model, inputs, debug=False, get_ts_graph=False):
     # With the current implementation we need to fetch the Torchscript graph
     # of a new model in order to fetch the new values of the weight.
     if get_ts_graph:
-        ts_g = torch.jit.script(fx_g)
+        ts_g = torch.jit.trace(fx_g, inputs)
         return ts_g, ts_g
 
     mlir_importer = SharkImporter(

--- a/shark/shark_importer.py
+++ b/shark/shark_importer.py
@@ -246,7 +246,7 @@ class SharkImporter:
 
 
 # Applies fx conversion to the model and imports the mlir.
-def import_with_fx(model, inputs, debug=False):
+def import_with_fx(model, inputs, debug=False, get_ts_graph=False):
     import torch
     from torch.fx.experimental.proxy_tensor import make_fx
     from torch._decomp import get_decompositions
@@ -285,6 +285,12 @@ def import_with_fx(model, inputs, debug=False):
         gm.recompile()
 
     strip_overloads(fx_g)
+
+    # With the current implementation we need to fetch the Torchscript graph
+    # of a new model in order to fetch the new values of the weight.
+    if get_ts_graph:
+        ts_g = torch.jit.script(fx_g)
+        return ts_g, ts_g
 
     mlir_importer = SharkImporter(
         fx_g,

--- a/shark/torch_mlir_utils.py
+++ b/shark/torch_mlir_utils.py
@@ -70,6 +70,7 @@ def get_torch_mlir_module(
         module,
         input,
         output_type=torch_mlir.OutputType.LINALG_ON_TENSORS,
+        use_external_references_if_numel_exceeds=0,
         use_tracing=jit_trace,
         ignore_traced_shapes=ignore_traced_shapes,
     )


### PR DESCRIPTION
This PR contains 7 commits :-

**Commit 1**
-- Adds `use_external_reference` flag to `torch_mlir.compile` to help gather all weight resources.

**Commit 2**
-- Adds checkpoint update feature on Clip, Unet and Vae.

**Commit 3**
-- Adds an assert to check that the current and the new values of weight match in shape.

**Commit 4**
-- Adds two fixes to the CKPT update feature.

**Commit 5**
-- Adds a way to monitor the CKPT update feature which the user can invoke by `show_checkpoint_update` flag.

**Commit 6**
-- Adds README.md entry to use CKPT update feature.

**Commit 7**
-- Fixes couple of lint errors.

This is based on the upstream `torch-mlir` branch which we're using for SHARK -> [cuda_f16](https://github.com/llvm/torch-mlir/tree/cuda_f16) since the patch which would help gather all weight resources outside the `forward` function has been added.

It also needs a temporary fix on IREE :-
1. PR raised on [SHARK-Runtime](https://github.com/nod-ai/SHARK-Runtime/pull/32)
2. Upstream issue being tracked [here](https://github.com/iree-org/iree/issues/11652)

CC: @powderluv @pashu123 