### PR TITLE
Change address for connection test

### DIFF
--- a/shark/shark_downloader.py
+++ b/shark/shark_downloader.py
@@ -198,7 +198,7 @@ def _internet_connected():
     import requests as req
 
     try:
-        req.get("http://1.1.1.1")
+        req.get("http://8.8.8.8")
         return True
     except:
         return False


### PR DESCRIPTION
Some ISP's (like mine) reserves 1.1.1.1 for internal testing, meaning _internet_connected(); needlessly retries for a minute until it fails even though my connection is fine. Propose 8.8.8.8 instead as this is also publically available and not normally blocked by ISPs.