### PR TITLE
Revert "Change address for connection test"

### DIFF
--- a/shark/shark_downloader.py
+++ b/shark/shark_downloader.py
@@ -201,7 +201,7 @@ def _internet_connected():
     import requests as req
 
     try:
-        req.get("http://8.8.8.8")
+        req.get("http://1.1.1.1")
         return True
     except:
         return False


### PR DESCRIPTION
Reverts nod-ai/SHARK#785

8.8.8.8 requires ICMP. 