### PR TITLE
fix: :bug: resolve css file path relative to __file__ & add demo.css to spec file for pyinstaller

### DIFF
--- a/web/index.py
+++ b/web/index.py
@@ -13,7 +13,7 @@ nodlogo_loc = resource_path("logos/nod-logo.png")
 sdlogo_loc = resource_path("logos/sd-demo-logo.png")
 
 
-demo_css = Path("demo.css").resolve()
+demo_css = Path(__file__).parent.joinpath("demo.css").resolve()
 
 
 with gr.Blocks(title="Stable Diffusion", css=demo_css) as shark_web:

--- a/web/shark_sd.spec
+++ b/web/shark_sd.spec
@@ -30,6 +30,7 @@ datas += [
          ( 'models/stable_diffusion/logos/*', 'logos' )
          ]
 datas += [('demo.css', '.')]
+
 binaries = []
 
 block_cipher = None

--- a/web/shark_sd.spec
+++ b/web/shark_sd.spec
@@ -29,7 +29,7 @@ datas += [
          ( 'models/stable_diffusion/resources/model_config.json', 'resources' ),
          ( 'models/stable_diffusion/logos/*', 'logos' )
          ]
-
+datas += [('demo.css', '.')]
 binaries = []
 
 block_cipher = None


### PR DESCRIPTION
Fixes [issues-816](https://github.com/nod-ai/SHARK/issues/816)
Also fixes issue reported in discord - exe did not have demo.css included

gets demo.css file path relative from index.pv \_\_file\_\_ parent rather than current working dir

add demo.css to spec file datas so its included in root folder of pyinstaller exe

