### PR TITLE
[SD-CLI] Fix vmfb naming + update README.md for `custom_model`

### DIFF
--- a/shark/examples/shark_inference/stable_diffusion/README.md
+++ b/shark/examples/shark_inference/stable_diffusion/README.md
@@ -55,15 +55,14 @@ use the flag `--variant=` to specify the model to be used.
 python .\shark\examples\shark_inference\stable_diffusion\main.py --variant=anythingv3 --max_length=77 --prompt="1girl, brown hair, green eyes, colorful, autumn, cumulonimbus clouds, lighting, blue sky, falling leaves, garden"
 ```
 
-## Using custom checkpoints for a specific version of a model:
-* To try this feature you may download [checkpoint-file](https://huggingface.co/andite/anything-v4.0/resolve/main/anything-v4.0-pruned-fp32.ckpt) in case you don't have locally generated `.ckpt` file for StableDiffusion.
-* Now pass the .ckpt file to [convert_original_stable_diffusion_to_diffusers.py](https://github.com/huggingface/diffusers/blob/main/scripts/convert_original_stable_diffusion_to_diffusers.py). Eg:
+## Using `custom_model` argument to run a custom model:
+* To try this feature you may download a [.ckpt](https://huggingface.co/andite/anything-v4.0/resolve/main/anything-v4.0-pruned-fp32.ckpt) file in case you don't have a locally generated `.ckpt` file for StableDiffusion.
+* Now pass the `.ckpt` file to [convert_original_stable_diffusion_to_diffusers.py](https://github.com/huggingface/diffusers/blob/main/scripts/convert_original_stable_diffusion_to_diffusers.py). Eg:
 ```shell
 python convert_original_stable_diffusion_to_diffusers.py --checkpoint_path="/path/to/ckpt/file" --dump_path="/path/to/dump/the/diffusers/structure"
 ```
 This would end up segregating the `.ckpt` file to match the structure of `diffusers`.
-* Now pass the diffusers' structure generated above to `model_variant` command-line flag using the following :-
+* Now pass the diffusers' structure generated above to `custom_model` command-line argument using the following :-
 ```shell
-python3.10 main.py --precision=fp32 --device=cuda --prompt="tajmahal, oil on canvas, sunflowers, 4k, uhd" --max_length=77 --version="v1_4" --model_variant="/path/to/dump/the/diffusers/structure"
+python3.10 main.py --precision=fp32 --device=cuda --prompt="tajmahal, oil on canvas, sunflowers, 4k, uhd" --max_length=77 --version="v1_4" --custom_model="/path/to/dump/the/diffusers/structure"
 ```
-* NOTE: You need to also specify `version` for the custom model you wanna run.

--- a/shark/examples/shark_inference/stable_diffusion/utils.py
+++ b/shark/examples/shark_inference/stable_diffusion/utils.py
@@ -23,8 +23,12 @@ def _compile_module(shark_module, model_name, extra_args=[]):
         # custom model.
         # So, currently, we add `custom_model_name` in the `extended_name` of
         # .vmfb file.
-        custom_model_name = "_".join(args.custom_model.split("/"))
-        extended_name = "{}_{}_{}".format(model_name, device, custom_model_name) 
+        # TODO: Have a better way of naming the vmfbs.
+        import re
+        custom_model_name = re.sub(r'\W+', '_', args.custom_model)
+        if custom_model_name != "" and custom_model_name[0] == "_":
+            custom_model_name = custom_model_name[1:]
+        extended_name = "{}_{}_{}".format(model_name, device, custom_model_name)
         vmfb_path = os.path.join(os.getcwd(), extended_name + ".vmfb")
         if args.load_vmfb and os.path.isfile(vmfb_path) and not args.save_vmfb:
             print(f"loading existing vmfb from: {vmfb_path}")


### PR DESCRIPTION
-- This commit introduces a fix for .vmfb naming to strip away any
   non-alphanumeric characters from `custom_model` path.
-- It also updates the README.md to include the `custom_model` arg.

Signed-off-by: Abhishek Varma <abhishek@nod-labs.com>