### PR TITLE
fix: replace malicious and deleted package

### DIFF
--- a/requirements-importer.txt
+++ b/requirements-importer.txt
@@ -3,7 +3,7 @@
 
 numpy==1.22.4
 torchvision
-torchtriton
+pytorch-triton
 tabulate
 
 tqdm


### PR DESCRIPTION
the package "torchtriton" was removed from pypi after it was discovered that it was utilized to initiate dependency confusion attack over PyTorch. PyTorch since replaced it with "pytorch-triton". 
you can read more about it here: https://medium.com/checkmarx-security/py-torch-a-leading-ml-framework-was-poisoned-with-malicious-dependency-e30f88242964