### PR TITLE
[SD-CLI] Reorder loading of opt_params when needed

### DIFF
--- a/shark/examples/shark_inference/stable_diffusion/main.py
+++ b/shark/examples/shark_inference/stable_diffusion/main.py
@@ -45,7 +45,6 @@ if args.clear_all:
 
 from utils import set_init_device_flags, disk_space_check
 
-from opt_params import get_unet, get_vae, get_clip
 from schedulers import (
     SharkEulerDiscreteScheduler,
 )
@@ -94,6 +93,8 @@ if __name__ == "__main__":
     disk_space_check(Path.cwd())
 
     if not args.import_mlir:
+        from opt_params import get_unet, get_vae, get_clip
+
         clip = get_clip()
         unet = get_unet()
         vae = get_vae()


### PR DESCRIPTION
-- This commit reorders loading of opt_params when `import_mlir` is not used.

Signed-off-by: Abhishek Varma <abhishek@nod-labs.com>