### PR TITLE
potential fix to pre-load DLL dir for torch-mlir

### DIFF
--- a/shark/examples/shark_inference/stable_diffusion/main.py
+++ b/shark/examples/shark_inference/stable_diffusion/main.py
@@ -1,6 +1,11 @@
 import os
+import sysconfig
 
 os.environ["AMD_ENABLE_LLPC"] = "1"
+# Preload DLL paths for torch-mlir
+os.add_dll_directory(
+    os.path.join(sysconfig.get_paths()["purelib"], "torch_mlir/_mlir_libs")
+)
 
 from transformers import CLIPTextModel, CLIPTokenizer
 import torch


### PR DESCRIPTION
Doesn't regress the main.py script but system already pre-loaded the DLL so needs more testing.