### PR TITLE
Add SD model annotation on fly

### DIFF
--- a/shark/examples/shark_inference/stable_diffusion/main.py
+++ b/shark/examples/shark_inference/stable_diffusion/main.py
@@ -121,6 +121,7 @@ if __name__ == "__main__":
             height=height,
             width=width,
             use_base_vae=args.use_base_vae,
+            use_tuned=args.use_tuned,
         )
         clip, unet, vae = mlir_import()
 

--- a/shark/examples/shark_inference/stable_diffusion/sd_annotation.py
+++ b/shark/examples/shark_inference/stable_diffusion/sd_annotation.py
@@ -1,15 +1,17 @@
 import os
 from shark.model_annotation import model_annotation, create_context
-from shark.iree_utils._common import run_cmd, iree_target_map
+from shark.iree_utils._common import iree_target_map, run_cmd
+from shark.shark_importer import import_with_fx
 from shark.shark_downloader import (
     download_model,
     download_public_file,
     WORKDIR,
 )
+from shark.shark_inference import SharkInference
 from shark.parser import shark_args
 from stable_args import args
-from opt_params import get_params
-from utils import set_init_device_flags
+from opt_params import get_params, version, variant
+from utils import set_init_device_flags, _compile_module
 
 
 set_init_device_flags()
@@ -17,65 +19,84 @@ device = (
     args.device if "://" not in args.device else args.device.split("://")[0]
 )
 
-# Downloads the model (Unet or VAE fp16) from shark_tank
-shark_args.local_tank_cache = args.local_tank_cache
-bucket_key = f"{args.variant}/untuned"
-if args.annotation_model == "unet":
-    model_key = f"{args.variant}/{args.version}/unet/{args.precision}/length_{args.max_length}/untuned"
-elif args.annotation_model == "vae":
-    is_base = "/base" if args.use_base_vae else ""
-    model_key = f"{args.variant}/{args.version}/vae/{args.precision}/length_77/untuned{is_base}"
 
-bucket, model_name, iree_flags = get_params(
-    bucket_key, model_key, args.annotation_model, "untuned", args.precision
-)
-mlir_model, func_name, inputs, golden_out = download_model(
-    model_name,
-    tank_url=bucket,
-    frontend="torch",
-)
+# Download the model (Unet or VAE fp16) from shark_tank
+def load_model_from_tank():
+    shark_args.local_tank_cache = args.local_tank_cache
+    bucket_key = f"{variant}/untuned"
+    if args.annotation_model == "unet":
+        model_key = f"{variant}/{version}/unet/{args.precision}/length_{args.max_length}/untuned"
+    elif args.annotation_model == "vae":
+        is_base = "/base" if args.use_base_vae else ""
+        model_key = f"{variant}/{version}/vae/{args.precision}/length_77/untuned{is_base}"
 
-# Downloads the tuned config files from shark_tank
-config_bucket = "gs://shark_tank/sd_tuned/configs/"
-if args.use_winograd:
+    bucket, model_name, iree_flags = get_params(
+        bucket_key, model_key, args.annotation_model, "untuned", args.precision
+    )
+    mlir_model, func_name, inputs, golden_out = download_model(
+        model_name,
+        tank_url=bucket,
+        frontend="torch",
+    )
+    return mlir_model, model_name
+
+
+# Download the tuned config files from shark_tank
+def load_winograd_configs():
+    config_bucket = "gs://shark_tank/sd_tuned/configs/"
     config_name = f"{args.annotation_model}_winograd_{device}.json"
     full_gs_url = config_bucket + config_name
     winograd_config_dir = f"{WORKDIR}configs/" + config_name
+    print("Loading Winograd config file from ", winograd_config_dir)
     download_public_file(full_gs_url, winograd_config_dir, True)
+    return winograd_config_dir
 
-if args.annotation_model == "unet" or device == "cuda":
-    if args.variant in ["anythingv3", "analogdiffusion"]:
+
+def load_lower_configs():
+    config_bucket = "gs://shark_tank/sd_tuned/configs/"
+    config_version = version
+    if variant in ["anythingv3", "analogdiffusion"]:
         args.max_length = 77
-        args.version = "v1_4"
+        config_version = "v1_4"
     if args.annotation_model == "vae":
         args.max_length = 77
-    config_name = f"{args.annotation_model}_{args.version}_{args.precision}_len{args.max_length}_{device}.json"
+    config_name = f"{args.annotation_model}_{config_version}_{args.precision}_len{args.max_length}_{device}.json"
     full_gs_url = config_bucket + config_name
     lowering_config_dir = f"{WORKDIR}configs/" + config_name
+    print("Loading lowering config file from ", lowering_config_dir)
     download_public_file(full_gs_url, lowering_config_dir, True)
+    return lowering_config_dir
+
 
 # Annotate the model with Winograd attribute on selected conv ops
-if args.use_winograd:
+def annotate_with_winograd(input_mlir, winograd_config_dir, model_name):
+    if model_name.split("_")[-1] != "tuned":
+        out_file_path = (
+            f"{args.annotation_output}/{model_name}_tuned_torch.mlir"
+        )
+    else:
+        out_file_path = f"{args.annotation_output}/{model_name}_torch.mlir"
+
     with create_context() as ctx:
         winograd_model = model_annotation(
             ctx,
-            input_contents=mlir_model,
+            input_contents=input_mlir,
             config_path=winograd_config_dir,
             search_op="conv",
-            winograd=args.use_winograd,
+            winograd=True,
         )
-        with open(
-            f"{args.annotation_output}/{model_name}_tuned_torch.mlir", "w"
-        ) as f:
+        with open(out_file_path, "w") as f:
             f.write(str(winograd_model))
+    return winograd_model, out_file_path
+
 
 # For Unet annotate the model with tuned lowering configs
-if args.annotation_model == "unet" or device == "cuda":
-    if args.use_winograd:
-        input_mlir = f"{args.annotation_output}/{model_name}_tuned_torch.mlir"
+def annotate_with_lower_configs(
+    input_mlir, lowering_config_dir, model_name, use_winograd
+):
+    if use_winograd:
         dump_after = "iree-linalg-ext-convert-conv2d-to-winograd"
     else:
-        input_mlir = f"{WORKDIR}{model_name}_torch/{model_name}_torch.mlir"
         dump_after = "iree-flow-pad-linalg-ops"
 
     # Dump IR after padding/img2col/winograd passes
@@ -90,6 +111,8 @@ if args.annotation_model == "unet" or device == "cuda":
         device_spec_args = (
             f"--iree-vulkan-target-triple={args.iree_vulkan_target_triple} "
         )
+    print("Applying tuned configs on", model_name)
+
     run_cmd(
         f"iree-compile {input_mlir} "
         "--iree-input-type=tm_tensor "
@@ -116,7 +139,85 @@ if args.annotation_model == "unet" or device == "cuda":
 
     # Remove the intermediate mlir and save the final annotated model
     os.remove(f"{args.annotation_output}/dump_after_winograd.mlir")
-    output_path = f"{args.annotation_output}/{model_name}_tuned_torch.mlir"
-    with open(output_path, "w") as f:
+    if model_name.split("_")[-1] != "tuned":
+        out_file_path = (
+            f"{args.annotation_output}/{model_name}_tuned_torch.mlir"
+        )
+    else:
+        out_file_path = f"{args.annotation_output}/{model_name}_torch.mlir"
+    with open(out_file_path, "w") as f:
         f.write(str(tuned_model))
+    return tuned_model, out_file_path
+
+
+def sd_model_annotation(mlir_model, model_name):
+    if args.annotation_model == "unet" and device == "vulkan":
+        use_winograd = True
+        winograd_config_dir = load_winograd_configs()
+        winograd_model, model_path = annotate_with_winograd(
+            mlir_model, winograd_config_dir, model_name
+        )
+        lowering_config_dir = load_lower_configs()
+        tuned_model, output_path = annotate_with_lower_configs(
+            model_path, lowering_config_dir, model_name, use_winograd
+        )
+    elif args.annotation_model == "vae" and device == "vulkan":
+        use_winograd = True
+        winograd_config_dir = load_winograd_configs()
+        tuned_model, output_path = annotate_with_winograd(
+            mlir_model, winograd_config_dir, model_name
+        )
+    else:
+        use_winograd = False
+        lowering_config_dir = load_lower_configs()
+        tuned_model, output_path = annotate_with_lower_configs(
+            mlir_model, lowering_config_dir, model_name, use_winograd
+        )
     print(f"Saved the annotated mlir in {output_path}.")
+    return tuned_model, output_path
+
+
+def tuned_compile_through_fx(
+    model,
+    inputs,
+    model_name,
+    is_f16=False,
+    f16_input_mask=None,
+    extra_args=[],
+):
+    tuned_model_path = f"{args.annotation_output}/{model_name}_torch.mlir"
+    if not os.path.exists(tuned_model_path):
+        mlir_module, func_name = import_with_fx(
+            model, inputs, is_f16, f16_input_mask, return_str=True
+        )
+        if "vae" in model_name.split("_")[0]:
+            args.annotation_model = "vae"
+
+        if device == "cuda":
+            output_path = f"{args.annotation_output}/{model_name}_orig.mlir"
+            with open(output_path, "w") as f:
+                f.write(mlir_module)
+            mlir_module = output_path
+
+        tuned_model, tuned_model_path = sd_model_annotation(
+            mlir_module, model_name
+        )
+
+    with open(tuned_model_path, "rb") as f:
+        tuned_module = f.read()
+
+    shark_module = SharkInference(
+        tuned_module,
+        device=args.device,
+        mlir_dialect="linalg",
+    )
+
+    return _compile_module(shark_module, model_name, extra_args)
+
+
+if __name__ == "__main__":
+    mlir_model, model_name = load_model_from_tank()
+    if device == "cuda":
+        mlir_model = f"{WORKDIR}{model_name}_torch/{model_name}_torch.mlir"
+
+    sd_model_annotation(mlir_model, model_name)

--- a/shark/examples/shark_inference/stable_diffusion/stable_args.py
+++ b/shark/examples/shark_inference/stable_diffusion/stable_args.py
@@ -93,7 +93,7 @@ p.add_argument(
 
 p.add_argument(
     "--import_mlir",
-    default=True,
+    default=False,
     action=argparse.BooleanOptionalAction,
     help="imports the model from torch module to shark_module otherwise downloads the model from shark_tank.",
 )
@@ -297,13 +297,6 @@ p.add_argument(
     type=str,
     default="unet",
     help="Options are unet and vae.",
-)
-
-p.add_argument(
-    "--use_winograd",
-    default=False,
-    action=argparse.BooleanOptionalAction,
-    help="Apply Winograd on selected conv ops.",
 )
 
 args = p.parse_args()

--- a/shark/examples/shark_inference/stable_diffusion/utils.py
+++ b/shark/examples/shark_inference/stable_diffusion/utils.py
@@ -77,7 +77,7 @@ def compile_through_fx(
 ):
 
     mlir_module, func_name = import_with_fx(
-        model, inputs, is_f16, f16_input_mask
+        model, inputs, is_f16, f16_input_mask, return_str=use_tuned
     )
 
     if use_tuned:
@@ -311,6 +311,11 @@ def get_opt_flags(model, precision="fp16"):
     if sys.platform == "darwin":
         iree_flags.append("-iree-stream-fuse-binding=false")
 
+    if "default_compilation_flags" in opt_flags[model][is_tuned][precision]:
+        iree_flags += opt_flags[model][is_tuned][precision][
+            "default_compilation_flags"
+        ]
+
     if "specified_compilation_flags" in opt_flags[model][is_tuned][precision]:
         device = (
             args.device
@@ -327,7 +332,6 @@ def get_opt_flags(model, precision="fp16"):
         iree_flags += opt_flags[model][is_tuned][precision][
             "specified_compilation_flags"
         ][device]
-
     return iree_flags
 
 

--- a/shark/model_annotation.py
+++ b/shark/model_annotation.py
@@ -162,7 +162,6 @@ def walk_children(
                         add_attributes(
                             child_op, configs[child_op_shape]["options"][0]
                         )
-                    print(f"Updated op {child_op}", file=sys.stderr)
 
                 walk_children(child_op, configs, search_op, winograd)
 
@@ -394,7 +393,6 @@ def add_winograd_attribute(op: ir.Operation, config: List):
         op.attributes["iree_winograd_conv"] = ir.IntegerAttr.get(
             ir.IntegerType.get_signless(64), 1
         )
-        print("Apply Winograd on selected conv op: ", op)
 
 
 def add_attribute_by_name(op: ir.Operation, name: str, val: int):

--- a/shark/shark_importer.py
+++ b/shark/shark_importer.py
@@ -55,6 +55,7 @@ class SharkImporter:
         inputs: tuple = (),
         frontend: str = "torch",
         raw_model_file: str = "",
+        return_str: bool = False,
     ):
         self.module = module
         self.inputs = None if len(inputs) == 0 else inputs
@@ -65,6 +66,7 @@ class SharkImporter:
             )
             sys.exit(1)
         self.raw_model_file = raw_model_file
+        self.return_str = return_str
 
     # NOTE: The default function for torch is "forward" and tf-lite is "main".
 
@@ -72,7 +74,11 @@ class SharkImporter:
         from shark.torch_mlir_utils import get_torch_mlir_module
 
         return get_torch_mlir_module(
-            self.module, self.inputs, is_dynamic, tracing_required
+            self.module,
+            self.inputs,
+            is_dynamic,
+            tracing_required,
+            self.return_str,
         )
 
     def _tf_mlir(self, func_name, save_dir="./shark_tmp/"):
@@ -357,6 +363,7 @@ def import_with_fx(
     f16_input_mask=None,
     debug=False,
     training=False,
+    return_str=False,
 ):
     import torch
     from torch.fx.experimental.proxy_tensor import make_fx
@@ -412,6 +419,7 @@ def import_with_fx(
         ts_graph,
         inputs,
         frontend="torch",
+        return_str=return_str,
     )
 
     if debug and not is_f16:

--- a/shark/torch_mlir_utils.py
+++ b/shark/torch_mlir_utils.py
@@ -56,6 +56,7 @@ def get_torch_mlir_module(
     input: tuple,
     dynamic: bool,
     jit_trace: bool,
+    return_str: bool,
 ):
     """Get the MLIR's linalg-on-tensors module from the torchscipt module."""
     ignore_traced_shapes = False
@@ -73,6 +74,8 @@ def get_torch_mlir_module(
         use_tracing=jit_trace,
         ignore_traced_shapes=ignore_traced_shapes,
     )
+    if return_str:
+        return mlir_module.operation.get_asm()
     bytecode_stream = io.BytesIO()
     mlir_module.operation.write_bytecode(bytecode_stream)
     bytecode = bytecode_stream.getvalue()

--- a/shark/torch_mlir_utils.py
+++ b/shark/torch_mlir_utils.py
@@ -56,7 +56,7 @@ def get_torch_mlir_module(
     input: tuple,
     dynamic: bool,
     jit_trace: bool,
-    return_str: bool,
+    return_str: bool = False,
 ):
     """Get the MLIR's linalg-on-tensors module from the torchscipt module."""
     ignore_traced_shapes = False


### PR DESCRIPTION
Annotation on fly function only works when this PR merged upstream https://github.com/llvm/torch-mlir/pull/1797.
Before this patch merged, we'll need to make sure `--no-use_tuned` is passed when `--import_mlir` is used. The default of `--import_mlir` is set as `False` for now.