### PR TITLE
[SD-CLI] Add `batch_size` command-line arg + prompt processing

### DIFF
--- a/shark/examples/shark_inference/stable_diffusion/README.md
+++ b/shark/examples/shark_inference/stable_diffusion/README.md
@@ -34,7 +34,25 @@ python3.10 main.py --precision=fp16 --device=vulkan --prompt="tajmahal, oil on c
 * Use custom model `.ckpt` files from [HuggingFace-StableDiffusion](https://huggingface.co/models?other=stable-diffusion) to generate images.
 
 
-
+## Running the model for a `batch_size` and for a set of `runs`:
+We currently support batch size in the range `[1, 3]`.
+You can specify batch size using `batch_size` flag (defaults to `1`) and the number of times you want to run the model using `runs` flag (defaults to `1`).
+In total, you'll be able to generate `batch_size * runs` number of images.
+- Usage 1: Using the same prompt -
+```shell
+python3.10 main.py --precision=fp16 --device=vulkan --prompt="tajmahal, oil on canvas, sunflowers, 4k, uhd" --max_length=64 --import_mlir --hf_model_id="runwayml/stable-diffusion-v1-5" --batch_size=3
+```
+The example above generates `3` different images in total with the same prompt `tajmahal, oil on canvas, sunflowers, 4k, uhd`.
+- Usage 2: Using different prompts -
+```shell
+python3.10 main.py --precision=fp16 --device=vulkan --prompt="tajmahal, oil on canvas, sunflowers, 4k, uhd" --max_length=64 --import_mlir --hf_model_id="runwayml/stable-diffusion-v1-5" --batch_size=3 -p="batman riding a horse, oil on canvas, 4k, uhd" -p="superman riding a horse, oil on canvas, 4k, uhd"
+```
+The example above generates `1` image for each different prompt, thus generating `3` images in total.
+- Usage 3: Using `runs` -
+```shell
+python3.10 main.py --precision=fp16 --device=vulkan --prompt="tajmahal, oil on canvas, sunflowers, 4k, uhd" --max_length=64 --import_mlir --hf_model_id="runwayml/stable-diffusion-v1-5" --batch_size=2 --runs=3
+```
+The example above generates `6` different images in total, `2` images for each `runs`.
 
 </details>
   <details>

--- a/shark/examples/shark_inference/stable_diffusion/main.py
+++ b/shark/examples/shark_inference/stable_diffusion/main.py
@@ -85,7 +85,16 @@ if __name__ == "__main__":
     # Scale for classifier-free guidance
     guidance_scale = torch.tensor(args.guidance_scale).to(torch.float32)
 
-    batch_size = len(prompt)
+    batch_size = args.batch_size
+    prompt = prompt * batch_size if len(prompt) == 1 else prompt
+    len_of_prompt = len(prompt)
+    assert (
+        len_of_prompt == batch_size
+    ), f"no. of prompts ({len_of_prompt}) is not equal to batch_size ({batch_size})"
+    print("Running StableDiffusion with the following config :-")
+    print(f"Batch size : {batch_size}")
+    print(f"Prompts : {prompt}")
+    print(f"Runs : {args.runs}")
 
     # Try to make neg_prompt equal to batch_size by appending blank strings.
     for i in range(batch_size - len(neg_prompt)):
@@ -286,7 +295,7 @@ if __name__ == "__main__":
         disk_space_check(output_path, lim=5)
         for i in range(batch_size):
             json_store = {
-                "prompt": args.prompts[i],
+                "prompt": prompt[i],
                 "negative prompt": args.negative_prompts[i],
                 "seed": args.seed,
                 "hf_model_id": args.hf_model_id,
@@ -295,8 +304,8 @@ if __name__ == "__main__":
                 "guidance_scale": args.guidance_scale,
                 "scheduler": args.scheduler,
             }
-            prompt_slice = re.sub("[^a-zA-Z0-9]", "_", args.prompts[i][:15])
-            img_name = f"{prompt_slice}_{args.seed}_{run}_{dt.now().strftime('%y%m%d_%H%M%S')}"
+            prompt_slice = re.sub("[^a-zA-Z0-9]", "_", prompt[i][:15])
+            img_name = f"{prompt_slice}_{args.seed}_{run}_{i}_{dt.now().strftime('%y%m%d_%H%M%S')}"
             if args.output_img_format == "jpg":
                 pil_images[i].save(
                     output_path / f"{img_name}.jpg",

--- a/shark/examples/shark_inference/stable_diffusion/stable_args.py
+++ b/shark/examples/shark_inference/stable_diffusion/stable_args.py
@@ -44,6 +44,14 @@ p.add_argument(
 )
 
 p.add_argument(
+    "--batch_size",
+    type=int,
+    default=1,
+    choices=range(1, 4),
+    help="the number of inferences to be made in a single `run`.",
+)
+
+p.add_argument(
     "--height",
     type=int,
     default=512,


### PR DESCRIPTION
-- This commit adds `batch_size` command-line arg.
-- It also involves replicating the prompt `batch_size` no. of times.

Signed-off-by: Abhishek Varma <abhishek@nod-labs.com>

NOTE:

1. If user specifies just `1` prompt along with `batch_size`, then we'll be using the same prompt for inferring.
2. Else if user provides `>1` prompt then we'd need the number of prompts to be `=batch_size`. This gives the user a space to introduce different prompts and see them all getting inferred.
3. `batch_size` has been restricted to stay between `[1, 3]` because beyond that it is currently generating garbage output.
4. So, we'd require `runs` flag in case user wants to generate some arbitrary number of images (`>3`).