### PR TITLE
[NFC] Rename SD negative_prompts flag

### DIFF
--- a/shark/examples/shark_inference/stable_diffusion/stable_args.py
+++ b/shark/examples/shark_inference/stable_diffusion/stable_args.py
@@ -23,7 +23,7 @@ p.add_argument(
 )
 
 p.add_argument(
-    "--negative-prompts",
+    "--negative_prompts",
     nargs="+",
     default=[""],
     help="text you don't want to see in the generated image.",


### PR DESCRIPTION
-- This commit renames SD negative_prompts flag.

Signed-off-by: Abhishek Varma <abhishek@nod-labs.com>

NOTE: Any unique prefix of a flag is a valid flag. So, if we have `prompts` then we can use any of the following :-
1. `--pro`
2. `--prom`
3. `--promp`
4. `--prompt`
5. `--prompts`