### PR TITLE
Map 2_1 to 2_1_base

### DIFF
--- a/apps/stable_diffusion/src/models/opt_params.py
+++ b/apps/stable_diffusion/src/models/opt_params.py
@@ -8,7 +8,7 @@ hf_model_variant_map = {
     "dreamlike-art/dreamlike-diffusion-1.0": ["dreamlike", "v2_1base"],
     "prompthero/openjourney": ["openjourney", "v2_1base"],
     "wavymulder/Analog-Diffusion": ["analogdiffusion", "v2_1base"],
-    "stabilityai/stable-diffusion-2-1": ["stablediffusion", "v2_1"],
+    "stabilityai/stable-diffusion-2-1": ["stablediffusion", "v2_1base"],
     "stabilityai/stable-diffusion-2-1-base": ["stablediffusion", "v2_1base"],
     "CompVis/stable-diffusion-v1-4": ["stablediffusion", "v1_4"],
 }

--- a/apps/stable_diffusion/src/utils/resources/model_db.json
+++ b/apps/stable_diffusion/src/utils/resources/model_db.json
@@ -1,6 +1,6 @@
 [
   {
-    "stablediffusion/untuned":"gs://shark_tank/latest",
+    "stablediffusion/untuned":"gs://shark_tank/sd_untuned",
     "stablediffusion/tuned":"gs://shark_tank/sd_tuned",
     "stablediffusion/tuned/cuda":"gs://shark_tank/sd_tuned/cuda",
     "anythingv3/untuned":"gs://shark_tank/sd_anythingv3",


### PR DESCRIPTION
we only have models in models_db for 2_1_base. now that diffusers is fixed we can actually generate 2_1 itself, but until we add support for that in the tank we should fetch 2_1_base for no-import_mlir