### PR TITLE
Disable tuned models for sm_89

### DIFF
--- a/apps/stable_diffusion/src/utils/utils.py
+++ b/apps/stable_diffusion/src/utils/utils.py
@@ -254,7 +254,6 @@ def set_init_device_flags():
         "sm_80",
         "sm_84",
         "sm_86",
-        "sm_89",
     ]:
         args.use_tuned = False
 


### PR DESCRIPTION
Looks like tuning on A100 doesn't necessarily translate to 40xx.