### PR TITLE
WebUi: Add support for more command arguments

### DIFF
--- a/apps/stable_diffusion/scripts/txt2img.py
+++ b/apps/stable_diffusion/scripts/txt2img.py
@@ -292,8 +292,8 @@ if __name__ == "__main__":
         args.use_tuned,
     )
 
-    for run in range(args.runs):
-        if run > 0:
+    for current_batch in range(args.batch_count):
+        if current_batch > 0:
             seed = -1
         seed = utils.sanitize_seed(seed)
 
@@ -323,7 +323,7 @@ if __name__ == "__main__":
         text_output += (
             f", batch size={args.batch_size}, max_length={args.max_length}"
         )
-        # TODO: if using --runs=x txt2img_obj.log will output on each display every iteration infos from the start
+        # TODO: if using --batch_count=x txt2img_obj.log will output on each display every iteration infos from the start
         text_output += txt2img_obj.log
         text_output += f"\nTotal image generation time: {total_time:.4f}sec"
 

--- a/apps/stable_diffusion/src/utils/stable_args.py
+++ b/apps/stable_diffusion/src/utils/stable_args.py
@@ -17,15 +17,15 @@ p = argparse.ArgumentParser(
 p.add_argument(
     "-p",
     "--prompts",
-    action="append",
-    default=[],
+    nargs="+",
+    default=["cyberpunk forest by Salvador Dali"],
     help="text of which images to be generated.",
 )
 
 p.add_argument(
     "--negative_prompts",
     nargs="+",
-    default=[""],
+    default=["trees, green"],
     help="text you don't want to see in the generated image.",
 )
 
@@ -39,8 +39,8 @@ p.add_argument(
 p.add_argument(
     "--seed",
     type=int,
-    default=42,
-    help="the seed to use.",
+    default=-1,
+    help="the seed to use. -1 for a random one.",
 )
 
 p.add_argument(
@@ -48,7 +48,7 @@ p.add_argument(
     type=int,
     default=1,
     choices=range(1, 4),
-    help="the number of inferences to be made in a single `run`.",
+    help="the number of inferences to be made in a single `batch_count`.",
 )
 
 p.add_argument(
@@ -148,10 +148,10 @@ p.add_argument(
 )
 
 p.add_argument(
-    "--runs",
+    "--batch_count",
     type=int,
     default=1,
-    help="number of images to be generated with random seeds in single execution",
+    help="number of batch to be generated with random seeds in single execution",
 )
 
 p.add_argument(
@@ -164,7 +164,7 @@ p.add_argument(
 p.add_argument(
     "--hf_model_id",
     type=str,
-    default="stabilityai/stable-diffusion-2-1-base",
+    default="",
     help="The repo-id of hugging face.",
 )
 
@@ -279,7 +279,7 @@ p.add_argument(
 
 p.add_argument(
     "--write_metadata_to_png",
-    default=False,
+    default=True,
     action=argparse.BooleanOptionalAction,
     help="flag for whether or not to save generation information in PNG chunk text to generated images.",
 )
@@ -292,7 +292,7 @@ p.add_argument(
     "--progress_bar",
     default=True,
     action=argparse.BooleanOptionalAction,
-    help="flag for removing the pregress bar animation during image generation",
+    help="flag for removing the progress bar animation during image generation",
 )
 
 p.add_argument(

--- a/apps/stable_diffusion/web/index.py
+++ b/apps/stable_diffusion/web/index.py
@@ -74,7 +74,7 @@ with gr.Blocks(title="Stable Diffusion", css=demo_css) as shark_web:
                         ckpt_files.extend(files)
                     custom_model = gr.Dropdown(
                         label=f"Models (Custom Model path: {ckpt_path})",
-                        value="None",
+                        value=args.ckpt_loc if args.ckpt_loc else "None",
                         choices=ckpt_files
                         + [
                             "Linaqruf/anything-v3.0",
@@ -87,28 +87,28 @@ with gr.Blocks(title="Stable Diffusion", css=demo_css) as shark_web:
                     )
                     hf_model_id = gr.Textbox(
                         placeholder="Select 'None' in the Models dropdown on the left and enter model ID here e.g: SG161222/Realistic_Vision_V1.3",
-                        value="",
+                        value=args.hf_model_id,
                         label="HuggingFace Model ID",
                     )
 
                 with gr.Group(elem_id="prompt_box_outer"):
                     prompt = gr.Textbox(
                         label="Prompt",
-                        value="cyberpunk forest by Salvador Dali",
+                        value=args.prompts[0],
                         lines=1,
                         elem_id="prompt_box",
                     )
                     negative_prompt = gr.Textbox(
                         label="Negative Prompt",
-                        value="trees, green",
+                        value=args.negative_prompts[0],
                         lines=1,
-                        elem_id="prompt_box",
+                        elem_id="negative_prompt_box",
                     )
                 with gr.Accordion(label="Advanced Options", open=False):
                     with gr.Row():
                         scheduler = gr.Dropdown(
                             label="Scheduler",
-                            value="SharkEulerDiscrete",
+                            value=args.scheduler,
                             choices=[
                                 "DDIM",
                                 "PNDM",
@@ -122,24 +122,24 @@ with gr.Blocks(title="Stable Diffusion", css=demo_css) as shark_web:
                         with gr.Group():
                             save_metadata_to_png = gr.Checkbox(
                                 label="Save prompt information to PNG",
-                                value=True,
+                                value=args.write_metadata_to_png,
                                 interactive=True,
                             )
                             save_metadata_to_json = gr.Checkbox(
                                 label="Save prompt information to JSON file",
-                                value=False,
+                                value=args.save_metadata_to_json,
                                 interactive=True,
                             )
                     with gr.Row():
                         height = gr.Slider(
-                            384, 786, value=512, step=8, label="Height"
+                            384, 786, value=args.height, step=8, label="Height"
                         )
                         width = gr.Slider(
-                            384, 786, value=512, step=8, label="Width"
+                            384, 786, value=args.width, step=8, label="Width"
                         )
                         precision = gr.Radio(
                             label="Precision",
-                            value="fp16",
+                            value=args.precision,
                             choices=[
                                 "fp16",
                                 "fp32",
@@ -148,7 +148,7 @@ with gr.Blocks(title="Stable Diffusion", css=demo_css) as shark_web:
                         )
                         max_length = gr.Radio(
                             label="Max Length",
-                            value=64,
+                            value=args.max_length,
                             choices=[
                                 64,
                                 77,
@@ -157,12 +157,12 @@ with gr.Blocks(title="Stable Diffusion", css=demo_css) as shark_web:
                         )
                     with gr.Row():
                         steps = gr.Slider(
-                            1, 100, value=50, step=1, label="Steps"
+                            1, 100, value=args.steps, step=1, label="Steps"
                         )
                         guidance_scale = gr.Slider(
                             0,
                             50,
-                            value=7.5,
+                            value=args.guidance_scale,
                             step=0.1,
                             label="CFG Scale",
                         )
@@ -170,7 +170,7 @@ with gr.Blocks(title="Stable Diffusion", css=demo_css) as shark_web:
                         batch_count = gr.Slider(
                             1,
                             10,
-                            value=1,
+                            value=args.batch_count,
                             step=1,
                             label="Batch Count",
                             interactive=True,
@@ -178,13 +178,15 @@ with gr.Blocks(title="Stable Diffusion", css=demo_css) as shark_web:
                         batch_size = gr.Slider(
                             1,
                             4,
-                            value=1,
+                            value=args.batch_size,
                             step=1,
                             label="Batch Size",
                             interactive=True,
                         )
                 with gr.Row():
-                    seed = gr.Number(value=-1, precision=0, label="Seed")
+                    seed = gr.Number(
+                        value=args.seed, precision=0, label="Seed"
+                    )
                     available_devices = get_available_devices()
                     device = gr.Dropdown(
                         label="Device",


### PR DESCRIPTION
Many command arguments are not supported in the webUi for now (width, height, prompt, max_length, etc.), they are forced to a static value declared in apps/stable_diffusion/web/index.py

Each time I launch the WebUi, I'm loosing time bringing back my favorite settings.
This PR try to address this issue:

All WebUi fields expect the **Device** can now be initialized at launch using the proper command argument.
Support was added in the WebUi for those arguments:
```
--hf_model_id, --prompts, --negative_prompts, --steps, --seed, --batch_size, --height, --width, --guidance_scale, --max_length, --precision, --scheduler, --batch_count, --batch_size, --ckpt_loc, --hf_model_id, --save_metadata_to_json, --write_metadata_to_png
```

* If a ckpt_loc is provided and available in the custom model dropdown , it should also be selected by default.
* I took the liberty to rename --runs by --batch_count, as this is what is displayed in the WebUi and mainly used by the stable diffusion community.

I also needed to tweak those argument default values in order to support this:

	--prompts: defaulted to ["cyberpunk forest by Salvador Dali"]
	--negative_prompts: defaulted to ["trees, green"]
	--seed: defaulted to -1
	--hf_model_id: defaulted to ""
	--write_metadata_to_png: defaulted to True


**Test session:**
I check a lot of combinations and didn't encountered problems so far, but it is pretty clear than covering all possible major cases is too much for me. If you think this is useful, it would be nice to have the community run further tests.

Thanks.
