### PR TITLE
Revert "Delete unnecessary arg setting"

### DIFF
--- a/apps/stable_diffusion/src/pipelines/pipeline_shark_stable_diffusion_utils.py
+++ b/apps/stable_diffusion/src/pipelines/pipeline_shark_stable_diffusion_utils.py
@@ -186,6 +186,8 @@ class StableDiffusionPipeline:
         use_tuned: bool,
     ):
         if import_mlir:
+            # TODO: Delet this when on-the-fly tuning of models work.
+            use_tuned = False
             mlir_import = SharkifyStableDiffusionModel(
                 model_id,
                 ckpt_loc,


### PR DESCRIPTION
Reverts nod-ai/SHARK#978. It will force --import_mlir to use untuned models until we have a fix on windows