### PR TITLE
Fix call to Torch Inductor

### DIFF
--- a/shark/shark_benchmark_runner.py
+++ b/shark/shark_benchmark_runner.py
@@ -118,9 +118,10 @@ class SharkBenchmarkRunner(SharkRunner):
         )
         HFmodel, input = get_torch_model(modelname)[:2]
         frontend_model = HFmodel.model
-        # frontend_model = dynamo.optimize("inductor")(frontend_model)
         frontend_model.to(torch_device)
         input.to(torch_device)
+
+        # frontend_model = torch.compile(frontend_model, mode="max-autotune", backend="inductor")
 
         for i in range(shark_args.num_warmup_iterations):
             frontend_model.forward(input)


### PR DESCRIPTION
Updates call to enable Torch Inductor.

To get Torch Inductor working, first update the version of Torch being run:

```
pip install numpy --pre torch[dynamo] --force-reinstall --extra-index-url https://download.pytorch.org/whl/nightly/cu117
```

This may cause dependency conflicts with `torch-mlir` so Torch imports may break.

Then uncomment the line:

```
#frontend_model = torch.compile(frontend_model, mode="max-autotune", backend="inductor")
```

in shark/shark_benchmark_runner.py