### PR TITLE
Add Stencil controlled SD in img2img pipeline

### DIFF
--- a/apps/stable_diffusion/src/models/model_wrappers.py
+++ b/apps/stable_diffusion/src/models/model_wrappers.py
@@ -300,7 +300,7 @@ class SharkifyStableDiffusionModel:
                     controlnet_cond=stencil_image,
                     return_dict=False,
                 )
-                return tuple(down_block_res_samples + [mid_block_res_sample])
+                return tuple(list(down_block_res_samples) + [mid_block_res_sample])
 
         scnet = StencilControlNetModel(low_cpu_mem_usage=self.low_cpu_mem_usage)
         is_f16 = True if self.precision == "fp16" else False

--- a/apps/stable_diffusion/src/models/model_wrappers.py
+++ b/apps/stable_diffusion/src/models/model_wrappers.py
@@ -286,12 +286,15 @@ class SharkifyStableDiffusionModel:
                 latent,
                 timestep,
                 text_embedding,
-                stencil_image,
+                stencil_image_input,
             ):
                 # expand the latents if we are doing classifier-free guidance to avoid doing two forward passes.
                 # TODO: guidance NOT NEEDED change in `get_input_info` later
                 latents = torch.cat(
                     [latent] * 2
+                )  # needs to be same as controlledUNET latents
+                stencil_image = torch.cat(
+                    [stencil_image_input] * 2
                 )  # needs to be same as controlledUNET latents
                 down_block_res_samples, mid_block_res_sample = self.cnet.forward(
                     latents,

--- a/apps/stable_diffusion/src/models/model_wrappers.py
+++ b/apps/stable_diffusion/src/models/model_wrappers.py
@@ -511,7 +511,6 @@ class SharkifyStableDiffusionModel:
                 )
 
             if need_stencil:
-                print(f"[DEBUG] Returning need_stencil")
                 return (
                     compiled_clip,
                     compiled_unet,

--- a/apps/stable_diffusion/src/models/model_wrappers.py
+++ b/apps/stable_diffusion/src/models/model_wrappers.py
@@ -408,7 +408,7 @@ class SharkifyStableDiffusionModel:
             
     # Compiles Clip, Unet and Vae with `base_model_id` as defining their input
     # configiration.
-    def compile_all(self, base_model_id, need_vae_encode):
+    def compile_all(self, base_model_id, need_vae_encode, need_stencil):
         self.inputs = get_input_info(
             base_models[base_model_id],
             self.max_len,
@@ -416,24 +416,32 @@ class SharkifyStableDiffusionModel:
             self.height,
             self.batch_size,
         )
-        compiled_controlnet = self.get_control_net()
-        compiled_controlled_unet = self.get_controlled_unet()
-        raise Exception("Testing stop - Compiled both Cnet CUNet")
-        compiled_unet = self.get_unet()
         if self.custom_vae != "":
             print("Plugging in custom Vae")
         compiled_vae = self.get_vae()
         compiled_clip = self.get_clip()
+        if need_stencil:
+            compiled_controlnet = self.get_control_net()
+            compiled_controlled_unet = self.get_controlled_unet()
+            return compiled_clip, compiled_controlled_unet, compiled_vae, compiled_controlnet
+
+        compiled_unet = self.get_unet()
         if need_vae_encode:
             compiled_vae_encode = self.get_vae_encode()
             return compiled_clip, compiled_unet, compiled_vae, compiled_vae_encode
 
-        return compiled_clip, compiled_unet, compiled_vae
+        return compiled_clip, compiled_unet, compiled_vae, None
 
     def __call__(self):
         # Step 1:
         # --  Fetch all vmfbs for the model, if present, else delete the lot.
-        need_vae_encode = args.img_path is not None
+        need_vae_encode, need_stencil = False, False
+        if args.img_path is not None:
+            if args.use_stencil is not None:
+                need_stencil = True
+            else:
+                need_vae_encode = True
+        print(f"[DEBUG] need_vae_encode: {need_vae_encode} need_stencil: {need_stencil}")
         self.model_name = self.get_extended_name_for_all_model()
         vmfbs = fetch_or_delete_vmfbs(self.model_name, need_vae_encode, self.precision)   
         if vmfbs[0]:
@@ -468,7 +476,7 @@ class SharkifyStableDiffusionModel:
             print("Compiling all the models with the fetched base model configuration.")
             if args.ckpt_loc != "":
                 args.hf_model_id = base_model_fetched
-            return self.compile_all(base_model_fetched, need_vae_encode)
+            return self.compile_all(base_model_fetched, need_vae_encode, need_stencil)
 
         # Step 3:
         # -- This is the retry mechanism where the base model's configuration is not
@@ -477,9 +485,11 @@ class SharkifyStableDiffusionModel:
         for model_id in base_models:
             try:
                 if need_vae_encode:
-                    compiled_clip, compiled_unet, compiled_vae, compiled_vae_encode = self.compile_all(model_id, need_vae_encode)
+                    compiled_clip, compiled_unet, compiled_vae, compiled_vae_encode = self.compile_all(model_id, need_vae_encode, need_stencil)
+                elif need_stencil:
+                    compiled_clip, compiled_unet, compiled_vae, compiled_controlnet = self.compile_all(model_id, need_vae_encode, need_stencil)
                 else:
-                    compiled_clip, compiled_unet, compiled_vae = self.compile_all(model_id, need_vae_encode)
+                    compiled_clip, compiled_unet, compiled_vae = self.compile_all(model_id, need_vae_encode, need_stencil)
             except Exception as e:
                 print("Retrying with a different base model configuration")
                 continue
@@ -499,6 +509,16 @@ class SharkifyStableDiffusionModel:
                     compiled_vae,
                     compiled_vae_encode,
                 )
+
+            if need_stencil:
+                print(f"[DEBUG] Returning need_stencil")
+                return (
+                    compiled_clip,
+                    compiled_unet,
+                    compiled_vae,
+                    compiled_controlnet,
+                )
+
             return compiled_clip, compiled_unet, compiled_vae
         sys.exit(
             "Cannot compile the model. Please create an issue with the detailed log at https://github.com/nod-ai/SHARK/issues"

--- a/apps/stable_diffusion/src/models/model_wrappers.py
+++ b/apps/stable_diffusion/src/models/model_wrappers.py
@@ -333,14 +333,11 @@ class SharkifyStableDiffusionModel:
             # TODO: Instead of flattening the `control` try to use the list.
             def forward(
                 self, latent, timestep, text_embedding, guidance_scale,
-                control1, control2, control3, control4, control5, control6, control7,
-                control8, control9, control10, control11, control12, control13
             ):
-                control = [control1, control2, control3, control4, control5, control6, control7, control8, control9, control10, control11, control12, control13]
                 # expand the latents if we are doing classifier-free guidance to avoid doing two forward passes.
                 latents = torch.cat([latent] * 2)
                 unet_out = self.unet.forward(
-                    latents, timestep, text_embedding, control=control, return_dict=False
+                    latents, timestep, text_embedding, return_dict=False
                 )[0]
                 noise_pred_uncond, noise_pred_text = unet_out.chunk(2)
                 noise_pred = noise_pred_uncond + guidance_scale * (

--- a/apps/stable_diffusion/src/pipelines/pipeline_shark_stable_diffusion_img2img.py
+++ b/apps/stable_diffusion/src/pipelines/pipeline_shark_stable_diffusion_img2img.py
@@ -185,7 +185,9 @@ class Image2ImagePipeline(StableDiffusionPipeline):
         final_timesteps = None
         stencil_t = None
         if use_stencil is not None:
-            stencil_t = self.preprocess_img(stencil_unprocessed, height, width, dtype)
+            stencil_t = self.preprocess_img(
+                stencil_unprocessed, height, width, dtype
+            )
             init_latents = self.prepare_latents(
                 batch_size=batch_size,
                 height=height,

--- a/apps/stable_diffusion/src/pipelines/pipeline_shark_stable_diffusion_img2img.py
+++ b/apps/stable_diffusion/src/pipelines/pipeline_shark_stable_diffusion_img2img.py
@@ -80,6 +80,7 @@ class Image2ImagePipeline(StableDiffusionPipeline):
         # expecting single image as input_image for stencil generation
         if type(input_image) == torch.Tensor:
             return input_image
+
         # if input image is of type PIL.Image.Image
         image_rs = np.resize(input_image, (width, height))
         image_arr = np.stack([np.array(i) for i in (image_rs,)], axis=0)
@@ -154,7 +155,7 @@ class Image2ImagePipeline(StableDiffusionPipeline):
         # Control Embedding check & conversion
         # TODO: 1. Change `num_images_per_prompt`.
         stencil_unprocessed = controlnet_hint_conversion(
-            image, use_stencil, height, width, num_images_per_prompt=1
+            image, use_stencil, height, width, dtype, num_images_per_prompt=1
         )
         # prompts and negative prompts must be a list.
         if isinstance(prompts, str):
@@ -184,8 +185,7 @@ class Image2ImagePipeline(StableDiffusionPipeline):
         final_timesteps = None
         stencil_t = None
         if use_stencil is not None:
-            stencil_t1 = self.preprocess_img(stencil_unprocessed, height, width, dtype)
-            stencil_t = torch.cat([stencil_t1] * 2)
+            stencil_t = self.preprocess_img(stencil_unprocessed, height, width, dtype)
             init_latents = self.prepare_latents(
                 batch_size=batch_size,
                 height=height,

--- a/apps/stable_diffusion/src/pipelines/pipeline_shark_stable_diffusion_utils.py
+++ b/apps/stable_diffusion/src/pipelines/pipeline_shark_stable_diffusion_utils.py
@@ -58,9 +58,6 @@ class StableDiffusionPipeline:
         # TODO: Make this dynamic like other models which'll be passed to StableDiffusionPipeline.
         from diffusers import UNet2DConditionModel
 
-        self.controlnet = UNet2DConditionModel.from_pretrained(
-            "/home/abhishek/weights/canny_weight", subfolder="controlnet"
-        )
 
     def encode_prompts(self, prompts, neg_prompts, max_length):
         # Tokenize text and get embeddings
@@ -156,7 +153,7 @@ class StableDiffusionPipeline:
                     ).to(dtype)
                 else:
                     latent_model_input_1 = latent_model_input
-                control = self.controlnet(
+                control = self.vae_encode( # contains controlnet
                     latent_model_input_1,
                     timestep,
                     encoder_hidden_states=text_embeddings,
@@ -340,6 +337,7 @@ class StableDiffusionPipeline:
                 low_cpu_mem_usage=low_cpu_mem_usage,
             )
             if cls.__name__ in ["Image2ImagePipeline", "InpaintPipeline"]:
+                # TESTING - VAE ENCODE will contain controlnet when using stencil
                 clip, unet, vae, vae_encode = mlir_import()
                 return cls(
                     vae_encode, vae, clip, get_tokenizer(), unet, scheduler

--- a/apps/stable_diffusion/src/pipelines/pipeline_shark_stable_diffusion_utils.py
+++ b/apps/stable_diffusion/src/pipelines/pipeline_shark_stable_diffusion_utils.py
@@ -153,11 +153,16 @@ class StableDiffusionPipeline:
                     ).to(dtype)
                 else:
                     latent_model_input_1 = latent_model_input
-                control = self.vae_encode( # contains controlnet
-                    latent_model_input_1,
-                    timestep,
-                    encoder_hidden_states=text_embeddings,
-                    controlnet_hint=controlnet_hint,
+                # contains control net for testing
+                control = self.vae_encode(
+                    "forward",
+                    (
+                        latent_model_input_1,
+                        timestep,
+                        text_embeddings,
+                        controlnet_hint,
+                    ),
+                    send_to_host=False,
                 )
                 timestep = timestep.detach().numpy()
                 # TODO: Pass `control` as it is to Unet. Same as TODO mentioned in model_wrappers.py.

--- a/apps/stable_diffusion/src/pipelines/pipeline_shark_stable_diffusion_utils.py
+++ b/apps/stable_diffusion/src/pipelines/pipeline_shark_stable_diffusion_utils.py
@@ -119,7 +119,7 @@ class StableDiffusionPipeline:
         total_timesteps,
         dtype,
         cpu_scheduling,
-        controlnet_hint=None,
+        stencil=None,
         mask=None,
         masked_image_latents=None,
         return_all_latents=False,
@@ -146,7 +146,7 @@ class StableDiffusionPipeline:
 
             # Profiling Unet.
             profile_device = start_profiling(file_path="unet.rdc")
-            if controlnet_hint is not None:
+            if stencil is not None:
                 if not torch.is_tensor(latent_model_input):
                     latent_model_input_1 = torch.from_numpy(
                         np.asarray(latent_model_input)
@@ -160,7 +160,7 @@ class StableDiffusionPipeline:
                         latent_model_input_1,
                         timestep,
                         text_embeddings,
-                        controlnet_hint,
+                        stencil,
                     ),
                     send_to_host=False,
                 )
@@ -169,7 +169,7 @@ class StableDiffusionPipeline:
                 noise_pred = self.unet(
                     "forward",
                     (
-                        latent_model_input,
+                        latent_model_input_1,
                         timestep,
                         text_embeddings_numpy,
                         guidance_scale,

--- a/apps/stable_diffusion/src/pipelines/pipeline_shark_stable_diffusion_utils.py
+++ b/apps/stable_diffusion/src/pipelines/pipeline_shark_stable_diffusion_utils.py
@@ -55,9 +55,6 @@ class StableDiffusionPipeline:
         self.scheduler = scheduler
         # TODO: Implement using logging python utility.
         self.log = ""
-        # TODO: Make this dynamic like other models which'll be passed to StableDiffusionPipeline.
-        from diffusers import UNet2DConditionModel
-
 
     def encode_prompts(self, prompts, neg_prompts, max_length):
         # Tokenize text and get embeddings

--- a/apps/stable_diffusion/src/utils/resources/base_model.json
+++ b/apps/stable_diffusion/src/utils/resources/base_model.json
@@ -143,55 +143,55 @@
                 "dtype": "f32"
             },
             "control1": {
-                "shape": [1, 320, 64, 64],
+                "shape": [2, 320, 64, 64],
                 "dtype": "f32"
             },
             "control2": {
-                "shape": [1, 320, 64, 64],
+                "shape": [2, 320, 64, 64],
                 "dtype": "f32"
             },
             "control3": {
-                "shape": [1, 320, 64, 64],
+                "shape": [2, 320, 64, 64],
                 "dtype": "f32"
             },
             "control4": {
-                "shape": [1, 320, 32, 32],
+                "shape": [2, 320, 32, 32],
                 "dtype": "f32"
             },
             "control5": {
-                "shape": [1, 640, 32, 32],
+                "shape": [2, 640, 32, 32],
                 "dtype": "f32"
             },
             "control6": {
-                "shape": [1, 640, 32, 32],
+                "shape": [2, 640, 32, 32],
                 "dtype": "f32"
             },
             "control7": {
-                "shape": [1, 640, 16, 16],
+                "shape": [2, 640, 16, 16],
                 "dtype": "f32"
             },
             "control8": {
-                "shape": [1, 1280, 16, 16],
+                "shape": [2, 1280, 16, 16],
                 "dtype": "f32"
             },
             "control9": {
-                "shape": [1, 1280, 16, 16],
+                "shape": [2, 1280, 16, 16],
                 "dtype": "f32"
             },
             "control10": {
-                "shape": [1, 1280, 8, 8],
+                "shape": [2, 1280, 8, 8],
                 "dtype": "f32"
             },
             "control11": {
-                "shape": [1, 1280, 8, 8],
+                "shape": [2, 1280, 8, 8],
                 "dtype": "f32"
             },
             "control12": {
-                "shape": [1, 1280, 8, 8],
+                "shape": [2, 1280, 8, 8],
                 "dtype": "f32"
             },
             "control13": {
-                "shape": [1, 1280, 8, 8],
+                "shape": [2, 1280, 8, 8],
                 "dtype": "f32"
             }
         },

--- a/apps/stable_diffusion/src/utils/stencils/stencil_utils.py
+++ b/apps/stable_diffusion/src/utils/stencils/stencil_utils.py
@@ -44,7 +44,7 @@ def resize_image(input_image, resolution):
 
 
 def controlnet_hint_shaping(
-    controlnet_hint, height, width, num_images_per_prompt=1
+    controlnet_hint, height, width, dtype, num_images_per_prompt=1
 ):
     channels = 3
     if isinstance(controlnet_hint, torch.Tensor):
@@ -54,7 +54,7 @@ def controlnet_hint_shaping(
         shape_nchw = (num_images_per_prompt, channels, height, width)
         if controlnet_hint.shape in [shape_chw, shape_bchw, shape_nchw]:
             controlnet_hint = controlnet_hint.to(
-                dtype=torch.float32, device=torch.device("cpu")
+                dtype=dtype, device=torch.device("cpu")
             )
             if controlnet_hint.shape != shape_nchw:
                 controlnet_hint = controlnet_hint.repeat(
@@ -80,7 +80,7 @@ def controlnet_hint_shaping(
         if controlnet_hint.shape in [shape_hwc, shape_bhwc, shape_nhwc]:
             controlnet_hint = torch.from_numpy(controlnet_hint.copy())
             controlnet_hint = controlnet_hint.to(
-                dtype=torch.float32, device=torch.device("cpu")
+                dtype=dtype, device=torch.device("cpu")
             )
             controlnet_hint /= 255.0
             if controlnet_hint.shape != shape_nhwc:
@@ -119,7 +119,7 @@ def controlnet_hint_shaping(
 
 
 def controlnet_hint_conversion(
-    image, use_stencil, height, width, num_images_per_prompt=1
+    image, use_stencil, height, width, dtype, num_images_per_prompt=1
 ):
     controlnet_hint = None
     match use_stencil:
@@ -128,9 +128,9 @@ def controlnet_hint_conversion(
             controlnet_hint = hint_canny(image, width)
         case _:
             return None
-    # controlnet_hint = controlnet_hint_shaping(
-    #     controlnet_hint, height, width, num_images_per_prompt
-    # )
+    controlnet_hint = controlnet_hint_shaping(
+        controlnet_hint, height, width, dtype, num_images_per_prompt
+    )
     return controlnet_hint
 
 

--- a/apps/stable_diffusion/src/utils/stencils/stencil_utils.py
+++ b/apps/stable_diffusion/src/utils/stencils/stencil_utils.py
@@ -128,9 +128,9 @@ def controlnet_hint_conversion(
             controlnet_hint = hint_canny(image, width)
         case _:
             return None
-    controlnet_hint = controlnet_hint_shaping(
-        controlnet_hint, height, width, num_images_per_prompt
-    )
+    # controlnet_hint = controlnet_hint_shaping(
+    #     controlnet_hint, height, width, num_images_per_prompt
+    # )
     return controlnet_hint
 
 


### PR DESCRIPTION
- adds functionality  for using stencil controlled image generation in the img2img pipeline
- currently supported stencils = canny edge detection

using stencils:
- specify input image for stencil creation and use `--img_path=`
- `--use_stencil=canny ` 
- prompt to get desired change on the stencil
- scheduler supported : DDIM

  
```
 python apps/stable_diffusion/scripts/img2img.py --prompt=<prompt text>  --import_mlir --no-load_vmfb --enable_stack_trace --no-use_tuned --hf_model_id="runwayml/stable-diffusion-v1-5" --scheduler="DDIM" --use_stencil=canny --img_path=<path to input image>
```