### PR TITLE
[WebUi] Reactivate gallery nav, Remove full_width for Image.style

### DIFF
--- a/apps/stable_diffusion/web/ui/css/sd_dark_theme.css
+++ b/apps/stable_diffusion/web/ui/css/sd_dark_theme.css
@@ -213,3 +213,9 @@ footer {
 #gallery + div {
     border-radius: 0 !important;
 }
+
+/* Prevent progress bar to block gallery navigation while building images (Gradio V3.19.0) */
+#gallery .wrap.default {
+    pointer-events: none;
+}
+

--- a/apps/stable_diffusion/web/ui/img2img_ui.py
+++ b/apps/stable_diffusion/web/ui/img2img_ui.py
@@ -76,7 +76,7 @@ with gr.Blocks(title="Image-to-Image") as img2img_web:
                     )
 
                 init_image = gr.Image(label="Input Image", type="pil").style(
-                    height=300, full_width=True
+                    height=300
                 )
 
                 with gr.Accordion(label="Advanced Options", open=False):

--- a/apps/stable_diffusion/web/ui/inpaint_ui.py
+++ b/apps/stable_diffusion/web/ui/inpaint_ui.py
@@ -76,7 +76,7 @@ with gr.Blocks(title="Inpainting") as inpaint_web:
                     source="upload",
                     tool="sketch",
                     type="pil",
-                ).style(height=350, full_width=True)
+                ).style(height=350)
 
                 with gr.Accordion(label="Advanced Options", open=False):
                     with gr.Row():

--- a/apps/stable_diffusion/web/ui/outpaint_ui.py
+++ b/apps/stable_diffusion/web/ui/outpaint_ui.py
@@ -72,7 +72,7 @@ with gr.Blocks(title="Outpainting") as outpaint_web:
                     )
 
                 init_image = gr.Image(label="Input Image", type="pil").style(
-                    height=300, full_width=True
+                    height=300
                 )
 
                 with gr.Accordion(label="Advanced Options", open=False):


### PR DESCRIPTION
* Fix a gallery navigation bug introduced in Gradio V3.19:
Gallery navigation (thumbnail bar, preview) is not responding when the progress bar is active and the gallery is generating images (batch count >1). This problem was introduced by Gradio V3.19.
* Remove the full_width parameter used in Image.style as this is not supported by Gradio.
```
J:\sd\SHARK\shark.venv\Lib\site-packages\gradio\components.py:148: UserWarning: Unknown style parameter: full_width
  warnings.warn(f"Unknown style parameter: {key}")
```