### PR TITLE
Run windows pytests in subprocesses

### DIFF
--- a/.github/workflows/test-models.yml
+++ b/.github/workflows/test-models.yml
@@ -151,8 +151,7 @@ jobs:
       if: matrix.suite == 'vulkan' && matrix.os == '7950x'
       run: |
         ./setup_venv.ps1
-        pytest -k vulkan -s
-        type bench_results.csv
+        pytest --forked -k vulkan -s 
 
     - name: Validate Stable Diffusion Models (Windows)
       if: matrix.suite == 'vulkan' && matrix.os == '7950x'


### PR DESCRIPTION
Also removes a command in the workflow .yaml that prints bench_results.csv (which won't be generated since benchmarks are disabled)