### PR TITLE
Move linting opts from github workflow to config files

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,5 @@
+[flake8]
+count = 1
+show-source = 1
+select = E9,F63,F7,F82
+exclude = lit.cfg.py

--- a/.github/workflows/test-models.yml
+++ b/.github/workflows/test-models.yml
@@ -99,11 +99,12 @@ jobs:
       run: |
         # black format check
         black --version
-        black --line-length 79 --check .
+        black --check .
         # stop the build if there are Python syntax errors or undefined names
-        flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics --exclude lit.cfg.py
+        flake8 . --statistics
         # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
-        flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics --exclude lit.cfg.py
+        flake8 . --isolated --count --exit-zero --max-complexity=10 --max-line-length=127 \
+          --statistics --exclude lit.cfg.py
 
     - name: Validate Models on CPU
       if: matrix.suite == 'cpu'

--- a/.style.yapf
+++ b/.style.yapf
@@ -1,3 +1,0 @@
-[style]
-  based_on_style = google
-  column_limit = 80

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,3 +10,6 @@ requires = [
     "iree-runtime>=20221022.190",
 ]
 build-backend = "setuptools.build_meta"
+
+[tool.black]
+line-length = 79


### PR DESCRIPTION
This helps development where you can be sure that running locally

black .
flake8 .

will do the same as in the github job.