### PR TITLE
Install IREE pre-releases

### DIFF
--- a/setup_venv.sh
+++ b/setup_venv.sh
@@ -102,7 +102,7 @@ else
 fi
 if [[ -z "${NO_BACKEND}" ]]; then
   echo "Installing ${RUNTIME}..."
-  $PYTHON -m pip install --upgrade --find-links ${RUNTIME} iree-compiler iree-runtime
+  $PYTHON -m pip install --pre --upgrade --find-links ${RUNTIME} iree-compiler iree-runtime
 else
   echo "Not installing a backend, please make sure to add your backend to PYTHONPATH"
 fi


### PR DESCRIPTION
The latest version of IREE being installed in SHARK is 20230221.437 (see [summary.html](https://storage.googleapis.com/shark-benchmark-artifacts/latest/summary.html)). Update `setup_venv.sh` to also install pre-releases.