### PR TITLE
Use utf-8 format for imgs_details.csv

### DIFF
--- a/apps/stable_diffusion/src/utils/utils.py
+++ b/apps/stable_diffusion/src/utils/utils.py
@@ -603,7 +603,7 @@ def save_output_img(output_img, img_seed, extra_info={}):
 
     new_entry.update(extra_info)
 
-    with open(csv_path, "a") as csv_obj:
+    with open(csv_path, "a", encoding="utf-8") as csv_obj:
         dictwriter_obj = DictWriter(csv_obj, fieldnames=list(new_entry.keys()))
         dictwriter_obj.writerow(new_entry)
         csv_obj.close()


### PR DESCRIPTION
Testing the png metadata import using images from civitai.com, one image reported me this error:

```
  File "D:\Stable_Diffusion\SHARK\apps\stable_diffusion\scripts\txt2img.py", line 162, in txt2img_inf
    save_output_img(out_imgs[0], img_seed)
  File "D:\Stable_Diffusion\SHARK\apps\stable_diffusion\src\utils\utils.py", line 608, in save_output_img
    dictwriter_obj.writerow(new_entry)
  File "C:\Users\m68k\AppData\Local\Programs\Python\Python311\Lib\csv.py", line 154, in writerow
    return self.writer.writerow(self._dict_to_list(rowdict))
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Users\m68k\AppData\Local\Programs\Python\Python311\Lib\encodings\cp1252.py", line 19, in encode
    return codecs.charmap_encode(input,self.errors,encoding_table)[0]
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
UnicodeEncodeError: 'charmap' codec can't encode character '\uff0c' in position 212: character maps to <undefined>
```

The problem was found in the negative prompt using a bad encoded comma:
Unicode Character 'FULLWIDTH COMMA' (U+FF0C)
```
"low quality，bad encoded comma"
```
Switching imgs_details.csv to utf-8 format fixed the problem.



