### PR TITLE
[Web] Improve dropdowns ux

### DIFF
--- a/apps/stable_diffusion/scripts/img2img.py
+++ b/apps/stable_diffusion/scripts/img2img.py
@@ -3,6 +3,7 @@ import torch
 import time
 from PIL import Image
 from dataclasses import dataclass
+from apps.stable_diffusion.web.ui.utils import get_custom_model_pathfile
 from apps.stable_diffusion.src import (
     args,
     Image2ImagePipeline,
@@ -110,7 +111,7 @@ def img2img_inf(
             )
         args.hf_model_id = hf_model_id
     elif ".ckpt" in custom_model or ".safetensors" in custom_model:
-        args.ckpt_loc = custom_model
+        args.ckpt_loc = get_custom_model_pathfile(custom_model)
     else:
         args.hf_model_id = custom_model
 

--- a/apps/stable_diffusion/scripts/inpaint.py
+++ b/apps/stable_diffusion/scripts/inpaint.py
@@ -1,8 +1,8 @@
-import sys
 import torch
 import time
 from PIL import Image
 from dataclasses import dataclass
+from apps.stable_diffusion.web.ui.utils import get_custom_model_pathfile
 from apps.stable_diffusion.src import (
     args,
     InpaintPipeline,
@@ -86,7 +86,7 @@ def inpaint_inf(
             )
         args.hf_model_id = hf_model_id
     elif ".ckpt" in custom_model or ".safetensors" in custom_model:
-        args.ckpt_loc = custom_model
+        args.ckpt_loc = get_custom_model_pathfile(custom_model)
     else:
         args.hf_model_id = custom_model
 

--- a/apps/stable_diffusion/scripts/outpaint.py
+++ b/apps/stable_diffusion/scripts/outpaint.py
@@ -1,8 +1,8 @@
-import sys
 import torch
 import time
 from PIL import Image
 from dataclasses import dataclass
+from apps.stable_diffusion.web.ui.utils import get_custom_model_pathfile
 from apps.stable_diffusion.src import (
     args,
     OutpaintPipeline,
@@ -88,7 +88,7 @@ def outpaint_inf(
             )
         args.hf_model_id = hf_model_id
     elif ".ckpt" in custom_model or ".safetensors" in custom_model:
-        args.ckpt_loc = custom_model
+        args.ckpt_loc = get_custom_model_pathfile(custom_model)
     else:
         args.hf_model_id = custom_model
 

--- a/apps/stable_diffusion/scripts/txt2img.py
+++ b/apps/stable_diffusion/scripts/txt2img.py
@@ -1,7 +1,7 @@
-import sys
 import torch
 import time
 from dataclasses import dataclass
+from apps.stable_diffusion.web.ui.utils import get_custom_model_pathfile
 from apps.stable_diffusion.src import (
     args,
     Text2ImagePipeline,
@@ -80,7 +80,7 @@ def txt2img_inf(
             )
         args.hf_model_id = hf_model_id
     elif ".ckpt" in custom_model or ".safetensors" in custom_model:
-        args.ckpt_loc = custom_model
+        args.ckpt_loc = get_custom_model_pathfile(custom_model)
     else:
         args.hf_model_id = custom_model
 

--- a/apps/stable_diffusion/web/ui/css/sd_dark_theme.css
+++ b/apps/stable_diffusion/web/ui/css/sd_dark_theme.css
@@ -223,3 +223,22 @@ footer {
 #txt2img_prompt_image .fixed-height {
     height: var(--size-32);
 }
+
+/* Hide "remove buttons" from ui dropdowns */
+#custom_model .token-remove.remove-all,
+#scheduler .token-remove.remove-all,
+#device .token-remove.remove-all {
+    display: none;
+}
+
+/* Hide selected items from ui dropdowns */
+#custom_model .options .item .inner-item,
+#scheduler .options .item .inner-item,
+#device .options .item .inner-item {
+    display:none;
+}
+
+/* Hide the download icon from the nod logo */
+#top_logo .download {
+    display: none;
+}

--- a/apps/stable_diffusion/web/ui/img2img_ui.py
+++ b/apps/stable_diffusion/web/ui/img2img_ui.py
@@ -1,4 +1,5 @@
 from pathlib import Path
+import os
 import gradio as gr
 from PIL import Image
 from apps.stable_diffusion.scripts import img2img_inf
@@ -30,10 +31,16 @@ with gr.Blocks(title="Image-to-Image") as img2img_web:
                 with gr.Row():
                     custom_model = gr.Dropdown(
                         label=f"Models (Custom Model path: {get_custom_model_path()})",
-                        value=args.ckpt_loc if args.ckpt_loc else "None",
-                        choices=get_custom_model_files() + predefined_models,
+                        elem_id="custom_model",
+                        value=os.path.basename(args.ckpt_loc)
+                        if args.ckpt_loc
+                        else "None",
+                        choices=["None"]
+                        + get_custom_model_files()
+                        + predefined_models,
                     )
                     hf_model_id = gr.Textbox(
+                        elem_id="hf_model_id",
                         placeholder="Select 'None' in the Models dropdown on the left and enter model ID here e.g: SG161222/Realistic_Vision_V1.3",
                         value="",
                         label="HuggingFace Model ID",
@@ -68,6 +75,7 @@ with gr.Blocks(title="Image-to-Image") as img2img_web:
                 with gr.Accordion(label="Advanced Options", open=False):
                     with gr.Row():
                         scheduler = gr.Dropdown(
+                            elem_id="scheduler",
                             label="Scheduler",
                             value="PNDM",
                             choices=scheduler_list,
@@ -117,7 +125,7 @@ with gr.Blocks(title="Image-to-Image") as img2img_web:
                             1,
                             value=args.strength,
                             step=0.01,
-                            label="Strength",
+                            label="Denoising Strength",
                         )
                     with gr.Row():
                         guidance_scale = gr.Slider(
@@ -149,6 +157,7 @@ with gr.Blocks(title="Image-to-Image") as img2img_web:
                         value=args.seed, precision=0, label="Seed"
                     )
                     device = gr.Dropdown(
+                        elem_id="device",
                         label="Device",
                         value=available_devices[0],
                         choices=available_devices,

--- a/apps/stable_diffusion/web/ui/inpaint_ui.py
+++ b/apps/stable_diffusion/web/ui/inpaint_ui.py
@@ -1,4 +1,5 @@
 from pathlib import Path
+import os
 import gradio as gr
 from PIL import Image
 from apps.stable_diffusion.scripts import inpaint_inf
@@ -30,11 +31,16 @@ with gr.Blocks(title="Inpainting") as inpaint_web:
                 with gr.Row():
                     custom_model = gr.Dropdown(
                         label=f"Models (Custom Model path: {get_custom_model_path()})",
-                        value=args.ckpt_loc if args.ckpt_loc else "None",
-                        choices=get_custom_model_files()
+                        elem_id="custom_model",
+                        value=os.path.basename(args.ckpt_loc)
+                        if args.ckpt_loc
+                        else "None",
+                        choices=["None"]
+                        + get_custom_model_files()
                         + predefined_paint_models,
                     )
                     hf_model_id = gr.Textbox(
+                        elem_id="hf_model_id",
                         placeholder="Select 'None' in the Models dropdown on the left and enter model ID here e.g: ghunkins/stable-diffusion-liberty-inpainting",
                         value="",
                         label="HuggingFace Model ID",
@@ -65,6 +71,7 @@ with gr.Blocks(title="Inpainting") as inpaint_web:
                 with gr.Accordion(label="Advanced Options", open=False):
                     with gr.Row():
                         scheduler = gr.Dropdown(
+                            elem_id="scheduler",
                             label="Scheduler",
                             value="PNDM",
                             choices=scheduler_list,
@@ -153,6 +160,7 @@ with gr.Blocks(title="Inpainting") as inpaint_web:
                         value=args.seed, precision=0, label="Seed"
                     )
                     device = gr.Dropdown(
+                        elem_id="device",
                         label="Device",
                         value=available_devices[0],
                         choices=available_devices,

--- a/apps/stable_diffusion/web/ui/outpaint_ui.py
+++ b/apps/stable_diffusion/web/ui/outpaint_ui.py
@@ -1,4 +1,5 @@
 from pathlib import Path
+import os
 import gradio as gr
 from PIL import Image
 from apps.stable_diffusion.scripts import outpaint_inf
@@ -30,11 +31,16 @@ with gr.Blocks(title="Outpainting") as outpaint_web:
                 with gr.Row():
                     custom_model = gr.Dropdown(
                         label=f"Models (Custom Model path: {get_custom_model_path()})",
-                        value=args.ckpt_loc if args.ckpt_loc else "None",
-                        choices=get_custom_model_files()
+                        elem_id="custom_model",
+                        value=os.path.basename(args.ckpt_loc)
+                        if args.ckpt_loc
+                        else "None",
+                        choices=["None"]
+                        + get_custom_model_files()
                         + predefined_paint_models,
                     )
                     hf_model_id = gr.Textbox(
+                        elem_id="hf_model_id",
                         placeholder="Select 'None' in the Models dropdown on the left and enter model ID here e.g: ghunkins/stable-diffusion-liberty-inpainting",
                         value="",
                         label="HuggingFace Model ID",
@@ -62,6 +68,7 @@ with gr.Blocks(title="Outpainting") as outpaint_web:
                 with gr.Accordion(label="Advanced Options", open=False):
                     with gr.Row():
                         scheduler = gr.Dropdown(
+                            elem_id="scheduler",
                             label="Scheduler",
                             value="PNDM",
                             choices=scheduler_list,
@@ -172,6 +179,7 @@ with gr.Blocks(title="Outpainting") as outpaint_web:
                         value=args.seed, precision=0, label="Seed"
                     )
                     device = gr.Dropdown(
+                        elem_id="device",
                         label="Device",
                         value=available_devices[0],
                         choices=available_devices,

--- a/apps/stable_diffusion/web/ui/txt2img_ui.py
+++ b/apps/stable_diffusion/web/ui/txt2img_ui.py
@@ -1,4 +1,5 @@
 from pathlib import Path
+import os
 import gradio as gr
 from PIL import Image
 from apps.stable_diffusion.scripts import txt2img_inf
@@ -31,13 +32,16 @@ with gr.Blocks(title="Text-to-Image") as txt2img_web:
                         with gr.Row():
                             custom_model = gr.Dropdown(
                                 label=f"Models (Custom Model path: {get_custom_model_path()})",
-                                value=args.ckpt_loc
+                                elem_id="custom_model",
+                                value=os.path.basename(args.ckpt_loc)
                                 if args.ckpt_loc
                                 else "None",
-                                choices=get_custom_model_files()
+                                choices=["None"]
+                                + get_custom_model_files()
                                 + predefined_models,
                             )
                             hf_model_id = gr.Textbox(
+                                elem_id="hf_model_id",
                                 placeholder="Select 'None' in the Models dropdown on the left and enter model ID here e.g: SG161222/Realistic_Vision_V1.3",
                                 value="",
                                 label="HuggingFace Model ID",
@@ -68,6 +72,7 @@ with gr.Blocks(title="Text-to-Image") as txt2img_web:
                 with gr.Accordion(label="Advanced Options", open=False):
                     with gr.Row():
                         scheduler = gr.Dropdown(
+                            elem_id="scheduler",
                             label="Scheduler",
                             value=args.scheduler,
                             choices=scheduler_list_txt2img,
@@ -141,6 +146,7 @@ with gr.Blocks(title="Text-to-Image") as txt2img_web:
                         value=args.seed, precision=0, label="Seed"
                     )
                     device = gr.Dropdown(
+                        elem_id="device",
                         label="Device",
                         value=available_devices[0],
                         choices=available_devices,

--- a/apps/stable_diffusion/web/ui/utils.py
+++ b/apps/stable_diffusion/web/ui/utils.py
@@ -53,12 +53,19 @@ def get_custom_model_path():
     return Path(args.ckpt_dir) if args.ckpt_dir else Path(Path.cwd(), "models")
 
 
+def get_custom_model_pathfile(custom_model_name):
+    return os.path.join(get_custom_model_path(), custom_model_name)
+
+
 def get_custom_model_files():
-    ckpt_files = ["None"]
+    ckpt_files = []
     for extn in custom_model_filetypes:
-        files = glob.glob(os.path.join(get_custom_model_path(), extn))
+        files = [
+            os.path.basename(x)
+            for x in glob.glob(os.path.join(get_custom_model_path(), extn))
+        ]
         ckpt_files.extend(files)
-    return ckpt_files
+    return sorted(ckpt_files, key=str.casefold)
 
 
 nodlogo_loc = resource_path("logos/nod-logo.png")

--- a/apps/stable_diffusion/web/utils/png_metadata.py
+++ b/apps/stable_diffusion/web/utils/png_metadata.py
@@ -1,5 +1,4 @@
 import re
-import os
 from pathlib import Path
 from apps.stable_diffusion.web.ui.txt2img_ui import (
     png_info_img,
@@ -15,7 +14,7 @@ from apps.stable_diffusion.web.ui.txt2img_ui import (
     hf_model_id,
 )
 from apps.stable_diffusion.web.ui.utils import (
-    get_custom_model_path,
+    get_custom_model_pathfile,
     scheduler_list_txt2img,
     predefined_models,
 )
@@ -83,10 +82,9 @@ def import_png_metadata(pil_data):
         png_hf_model_id = ""
 
         # Check for a model match with one of the local ckpt or safetensors files
-        ckpt_path = get_custom_model_path()
-        png_custom_model = os.path.join(ckpt_path, metadata["Model"])
-        if not Path(png_custom_model).is_file():
-            png_custom_model = "None"
+        png_custom_model = "None"
+        if Path(get_custom_model_pathfile(metadata["Model"])).is_file():
+            png_custom_model = metadata["Model"]
         # Check for a model match with one of the default model list (ex: "Linaqruf/anything-v3.0")
         if metadata["Model"] in predefined_models:
             png_custom_model = metadata["Model"]


### PR DESCRIPTION
Hello, 
This should fix most of the Ui display problems introduced by Gradio 3.20

* Hide the download icon from the nod logo.
* Hide delete buttons visible in dropdowns.
* Hide selected icons visible next to dropdown entries.
* Display model names only (without fullpath) in model dropdowns.
* ckpt & safetensors names alphabetically sorted in model dropdowns.
* Renamed the "Strength" label in image-to-image tab by "Denoising Strength".

Note: For the download logo icon, I took the fast and lazy path, just hiding it. A safer option would have been to replace the image component by a html one. Perhaps for a later upgrade if a logo problem pop again.

Tested on all tabs, python version, windows binary distribution, and txt2img command line.

Have a nice week, and thanks a lot for this really cool project. :)

