### PR TITLE
Fix png metadata

### DIFF
--- a/apps/stable_diffusion/src/utils/utils.py
+++ b/apps/stable_diffusion/src/utils/utils.py
@@ -559,7 +559,7 @@ def save_output_img(output_img, img_seed, extra_info={}):
 
     img_model = args.hf_model_id
     if args.ckpt_loc:
-        img_model = os.path.basename(args.ckpt_loc)
+        img_model = Path(os.path.basename(args.ckpt_loc)).stem
 
     if args.output_img_format == "jpg":
         out_img_path = Path(generated_imgs_path, f"{out_img_name}.jpg")


### PR DESCRIPTION

* Remove the custom model file extension from generated metadata. This adds compatibility with metadata generated by Auto1111.
* Better parsing from the WebUi "Import PNG info" box: Missing models are now reported in the console instead of the "hf model id " field. That was a pretty bad idea, and it should be less confusing for newcomers.

Note: It's now possible to drag&drop an image from civitai and import supported info. 