### PR TITLE
Add flag to augment the device allocator

### DIFF
--- a/shark/iree_utils/compile_utils.py
+++ b/shark/iree_utils/compile_utils.py
@@ -293,7 +293,8 @@ def get_iree_module(flatbuffer_blob, device, device_idx=None):
         haldriver = ireert.get_driver(device)
 
         haldevice = haldriver.create_device(
-            haldriver.query_available_devices()[device_idx]["device_id"]
+            haldriver.query_available_devices()[device_idx]["device_id"],
+            allocators=shark_args.device_allocator,
         )
         config = ireert.Config(device=haldevice)
     else:
@@ -402,5 +403,10 @@ def get_results(
 
 def get_iree_runtime_config(device):
     device = iree_device_map(device)
-    config = ireert.Config(device=ireert.get_device(device))
+    haldriver = ireert.get_driver(device)
+    haldevice = haldriver.create_device_by_uri(
+        device,
+        allocators=shark_args.device_allocator,
+    )
+    config = ireert.Config(device=haldevice)
     return config

--- a/shark/parser.py
+++ b/shark/parser.py
@@ -108,4 +108,14 @@ parser.add_argument(
     help="Enables the --iree-flow-enable-conv-winograd-transform flag.",
 )
 
+parser.add_argument(
+    "--device_allocator",
+    type=str,
+    nargs="*",
+    default=[],
+    help="Specifies one or more HAL device allocator specs "
+    "to augment the base device allocator",
+    choices=["debug", "caching"],
+)
+
 shark_args, unknown = parser.parse_known_args()


### PR DESCRIPTION
Example:
$ python my_app.py --device_allocator caching debug
This will wrap the device allocator with first caching allocator then debug allocator.

$ python my_app.py --device_allocator caching
Only wrap with caching allocator.