### PR TITLE
Add benchmark artifacts to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -168,6 +168,8 @@ shark_tmp/
 *.vmfb
 .use-iree
 tank/dict_configs.py
+*.csv
+reproducers/
 
 # ORT related artefacts
 cache_models/


### PR DESCRIPTION
Ignore artifacts created by `pytest --benchmark tank/test_models.py`