### PR TITLE
Clear memory cache when switching model and mode

### DIFF
--- a/apps/stable_diffusion/scripts/img2img.py
+++ b/apps/stable_diffusion/scripts/img2img.py
@@ -2,7 +2,6 @@ import sys
 import torch
 import time
 from PIL import Image
-from dataclasses import dataclass
 from apps.stable_diffusion.src import (
     args,
     Image2ImagePipeline,
@@ -15,21 +14,6 @@ from apps.stable_diffusion.src import (
 )
 
 
-@dataclass
-class Config:
-    model_id: str
-    ckpt_loc: str
-    precision: str
-    batch_size: int
-    max_length: int
-    height: int
-    width: int
-    device: str
-    use_stencil: str
-
-
-img2img_obj = None
-config_obj = None
 schedulers = None
 
 # set initial values of iree_vulkan_target_triple, use_tuned and import_mlir.
@@ -88,10 +72,12 @@ def img2img_inf(
     save_metadata_to_json: bool,
     save_metadata_to_png: bool,
 ):
-    from apps.stable_diffusion.web.ui.utils import get_custom_model_pathfile
+    from apps.stable_diffusion.web.ui.utils import (
+        get_custom_model_pathfile,
+        Config,
+    )
+    import apps.stable_diffusion.web.utils.global_obj as global_obj
 
-    global img2img_obj
-    global config_obj
     global schedulers
 
     args.prompts = [prompt]
@@ -149,6 +135,7 @@ def img2img_inf(
     args.precision = precision
     dtype = torch.float32 if precision == "fp32" else torch.half
     new_config_obj = Config(
+        "img2img",
         args.hf_model_id,
         args.ckpt_loc,
         precision,
@@ -157,10 +144,15 @@ def img2img_inf(
         height,
         width,
         device,
-        use_stencil,
+        use_lora=None,
+        use_stencil=use_stencil,
     )
-    if not img2img_obj or config_obj != new_config_obj:
-        config_obj = new_config_obj
+    if (
+        not global_obj.get_sd_obj()
+        or global_obj.get_cfg_obj() != new_config_obj
+    ):
+        global_obj.clear_cache()
+        global_obj.set_cfg_obj(new_config_obj)
         args.batch_size = batch_size
         args.max_length = max_length
         args.height = height
@@ -180,45 +172,49 @@ def img2img_inf(
 
         if use_stencil is not None:
             args.use_tuned = False
-            img2img_obj = StencilPipeline.from_pretrained(
-                scheduler_obj,
-                args.import_mlir,
-                args.hf_model_id,
-                args.ckpt_loc,
-                args.custom_vae,
-                args.precision,
-                args.max_length,
-                args.batch_size,
-                args.height,
-                args.width,
-                args.use_base_vae,
-                args.use_tuned,
-                low_cpu_mem_usage=args.low_cpu_mem_usage,
-                use_stencil=use_stencil,
-                debug=args.import_debug if args.import_mlir else False,
+            global_obj.set_sd_obj(
+                StencilPipeline.from_pretrained(
+                    scheduler_obj,
+                    args.import_mlir,
+                    args.hf_model_id,
+                    args.ckpt_loc,
+                    args.custom_vae,
+                    args.precision,
+                    args.max_length,
+                    args.batch_size,
+                    args.height,
+                    args.width,
+                    args.use_base_vae,
+                    args.use_tuned,
+                    low_cpu_mem_usage=args.low_cpu_mem_usage,
+                    use_stencil=use_stencil,
+                    debug=args.import_debug if args.import_mlir else False,
+                )
             )
         else:
-            img2img_obj = Image2ImagePipeline.from_pretrained(
-                scheduler_obj,
-                args.import_mlir,
-                args.hf_model_id,
-                args.ckpt_loc,
-                args.custom_vae,
-                args.precision,
-                args.max_length,
-                args.batch_size,
-                args.height,
-                args.width,
-                args.use_base_vae,
-                args.use_tuned,
-                low_cpu_mem_usage=args.low_cpu_mem_usage,
-                debug=args.import_debug if args.import_mlir else False,
+            global_obj.set_sd_obj(
+                Image2ImagePipeline.from_pretrained(
+                    scheduler_obj,
+                    args.import_mlir,
+                    args.hf_model_id,
+                    args.ckpt_loc,
+                    args.custom_vae,
+                    args.precision,
+                    args.max_length,
+                    args.batch_size,
+                    args.height,
+                    args.width,
+                    args.use_base_vae,
+                    args.use_tuned,
+                    low_cpu_mem_usage=args.low_cpu_mem_usage,
+                    debug=args.import_debug if args.import_mlir else False,
+                )
             )
 
-    img2img_obj.scheduler = schedulers[scheduler]
+    global_obj.set_schedulers(schedulers[scheduler])
 
     start_time = time.time()
-    img2img_obj.log = ""
+    global_obj.get_sd_obj().log = ""
     generated_imgs = []
     seeds = []
     img_seed = utils.sanitize_seed(seed)
@@ -226,7 +222,7 @@ def img2img_inf(
     for current_batch in range(batch_count):
         if current_batch > 0:
             img_seed = utils.sanitize_seed(-1)
-        out_imgs = img2img_obj.generate_images(
+        out_imgs = global_obj.get_sd_obj().generate_images(
             prompt,
             negative_prompt,
             image,
@@ -246,8 +242,8 @@ def img2img_inf(
         save_output_img(out_imgs[0], img_seed, extra_info)
         generated_imgs.extend(out_imgs)
         seeds.append(img_seed)
-        img2img_obj.log += "\n"
-        yield generated_imgs, generated_imgs[0], img2img_obj.log
+        global_obj.get_sd_obj().log += "\n"
+        yield generated_imgs, generated_imgs[0], global_obj.get_sd_obj().log
 
     total_time = time.time() - start_time
     text_output = f"prompt={args.prompts}"
@@ -256,7 +252,7 @@ def img2img_inf(
     text_output += f"\nscheduler={args.scheduler}, device={device}"
     text_output += f"\nsteps={steps}, strength={args.strength}, guidance_scale={guidance_scale}, seed={seeds}"
     text_output += f"\nsize={height}x{width}, batch_count={batch_count}, batch_size={batch_size}, max_length={args.max_length}"
-    text_output += img2img_obj.log
+    text_output += global_obj.get_sd_obj().log
     text_output += f"\nTotal image generation time: {total_time:.4f}sec"
 
     yield generated_imgs, text_output

--- a/apps/stable_diffusion/scripts/inpaint.py
+++ b/apps/stable_diffusion/scripts/inpaint.py
@@ -1,7 +1,6 @@
 import torch
 import time
 from PIL import Image
-from dataclasses import dataclass
 from apps.stable_diffusion.src import (
     args,
     InpaintPipeline,
@@ -13,20 +12,6 @@ from apps.stable_diffusion.src import (
 )
 
 
-@dataclass
-class Config:
-    model_id: str
-    ckpt_loc: str
-    precision: str
-    batch_size: int
-    max_length: int
-    height: int
-    width: int
-    device: str
-
-
-inpaint_obj = None
-config_obj = None
 schedulers = None
 
 # set initial values of iree_vulkan_target_triple, use_tuned and import_mlir.
@@ -58,10 +43,12 @@ def inpaint_inf(
     save_metadata_to_json: bool,
     save_metadata_to_png: bool,
 ):
-    from apps.stable_diffusion.web.ui.utils import get_custom_model_pathfile
+    from apps.stable_diffusion.web.ui.utils import (
+        get_custom_model_pathfile,
+        Config,
+    )
+    import apps.stable_diffusion.web.utils.global_obj as global_obj
 
-    global inpaint_obj
-    global config_obj
     global schedulers
 
     args.prompts = [prompt]
@@ -97,6 +84,7 @@ def inpaint_inf(
     dtype = torch.float32 if precision == "fp32" else torch.half
     cpu_scheduling = not scheduler.startswith("Shark")
     new_config_obj = Config(
+        "inpaint",
         args.hf_model_id,
         args.ckpt_loc,
         precision,
@@ -105,9 +93,15 @@ def inpaint_inf(
         height,
         width,
         device,
+        use_lora=None,
+        use_stencil=None,
     )
-    if not inpaint_obj or config_obj != new_config_obj:
-        config_obj = new_config_obj
+    if (
+        not global_obj.get_sd_obj()
+        or global_obj.get_cfg_obj() != new_config_obj
+    ):
+        global_obj.clear_cache()
+        global_obj.set_cfg_obj(new_config_obj)
         args.precision = precision
         args.batch_size = batch_size
         args.max_length = max_length
@@ -125,27 +119,29 @@ def inpaint_inf(
         )
         schedulers = get_schedulers(model_id)
         scheduler_obj = schedulers[scheduler]
-        inpaint_obj = InpaintPipeline.from_pretrained(
-            scheduler=scheduler_obj,
-            import_mlir=args.import_mlir,
-            model_id=args.hf_model_id,
-            ckpt_loc=args.ckpt_loc,
-            precision=args.precision,
-            max_length=args.max_length,
-            batch_size=args.batch_size,
-            height=args.height,
-            width=args.width,
-            use_base_vae=args.use_base_vae,
-            use_tuned=args.use_tuned,
-            custom_vae=args.custom_vae,
-            low_cpu_mem_usage=args.low_cpu_mem_usage,
-            debug=args.import_debug if args.import_mlir else False,
+        global_obj.set_sd_obj(
+            InpaintPipeline.from_pretrained(
+                scheduler=scheduler_obj,
+                import_mlir=args.import_mlir,
+                model_id=args.hf_model_id,
+                ckpt_loc=args.ckpt_loc,
+                precision=args.precision,
+                max_length=args.max_length,
+                batch_size=args.batch_size,
+                height=args.height,
+                width=args.width,
+                use_base_vae=args.use_base_vae,
+                use_tuned=args.use_tuned,
+                custom_vae=args.custom_vae,
+                low_cpu_mem_usage=args.low_cpu_mem_usage,
+                debug=args.import_debug if args.import_mlir else False,
+            )
         )
 
-    inpaint_obj.scheduler = schedulers[scheduler]
+    global_obj.set_schedulers(schedulers[scheduler])
 
     start_time = time.time()
-    inpaint_obj.log = ""
+    global_obj.get_sd_obj().log = ""
     generated_imgs = []
     seeds = []
     img_seed = utils.sanitize_seed(seed)
@@ -154,7 +150,7 @@ def inpaint_inf(
     for i in range(batch_count):
         if i > 0:
             img_seed = utils.sanitize_seed(-1)
-        out_imgs = inpaint_obj.generate_images(
+        out_imgs = global_obj.get_sd_obj().generate_images(
             prompt,
             negative_prompt,
             image,
@@ -175,8 +171,8 @@ def inpaint_inf(
         save_output_img(out_imgs[0], img_seed)
         generated_imgs.extend(out_imgs)
         seeds.append(img_seed)
-        inpaint_obj.log += "\n"
-        yield generated_imgs, generated_imgs[0], inpaint_obj.log
+        global_obj.get_sd_obj().log += "\n"
+        yield generated_imgs, generated_imgs[0], global_obj.get_sd_obj().log
 
     total_time = time.time() - start_time
     text_output = f"prompt={args.prompts}"
@@ -185,7 +181,7 @@ def inpaint_inf(
     text_output += f"\nscheduler={args.scheduler}, device={device}"
     text_output += f"\nsteps={args.steps}, guidance_scale={args.guidance_scale}, seed={seeds}"
     text_output += f"\nsize={args.height}x{args.width}, batch-count={batch_count}, batch-size={args.batch_size}, max_length={args.max_length}"
-    text_output += inpaint_obj.log
+    text_output += global_obj.get_sd_obj().log
     text_output += f"\nTotal image generation time: {total_time:.4f}sec"
 
     yield generated_imgs, text_output

--- a/apps/stable_diffusion/scripts/txt2img.py
+++ b/apps/stable_diffusion/scripts/txt2img.py
@@ -1,6 +1,5 @@
 import torch
 import time
-from dataclasses import dataclass
 from apps.stable_diffusion.src import (
     args,
     Text2ImagePipeline,
@@ -12,21 +11,6 @@ from apps.stable_diffusion.src import (
 )
 
 
-@dataclass
-class Config:
-    model_id: str
-    ckpt_loc: str
-    precision: str
-    batch_size: int
-    max_length: int
-    height: int
-    width: int
-    device: str
-    use_lora: str
-
-
-txt2img_obj = None
-config_obj = None
 schedulers = None
 
 # set initial values of iree_vulkan_target_triple, use_tuned and import_mlir.
@@ -57,10 +41,12 @@ def txt2img_inf(
     lora_weights: str,
     lora_hf_id: str,
 ):
-    from apps.stable_diffusion.web.ui.utils import get_custom_model_pathfile
+    from apps.stable_diffusion.web.ui.utils import (
+        get_custom_model_pathfile,
+        Config,
+    )
+    import apps.stable_diffusion.web.utils.global_obj as global_obj
 
-    global txt2img_obj
-    global config_obj
     global schedulers
 
     args.prompts = [prompt]
@@ -103,6 +89,7 @@ def txt2img_inf(
     dtype = torch.float32 if precision == "fp32" else torch.half
     cpu_scheduling = not scheduler.startswith("Shark")
     new_config_obj = Config(
+        "txt2img",
         args.hf_model_id,
         args.ckpt_loc,
         precision,
@@ -111,10 +98,15 @@ def txt2img_inf(
         height,
         width,
         device,
-        use_lora,
+        use_lora=use_lora,
+        use_stencil=None,
     )
-    if not txt2img_obj or config_obj != new_config_obj:
-        config_obj = new_config_obj
+    if (
+        not global_obj.get_sd_obj()
+        or global_obj.get_cfg_obj() != new_config_obj
+    ):
+        global_obj.clear_cache()
+        global_obj.set_cfg_obj(new_config_obj)
         args.precision = precision
         args.batch_size = batch_size
         args.max_length = max_length
@@ -133,35 +125,37 @@ def txt2img_inf(
         )
         schedulers = get_schedulers(model_id)
         scheduler_obj = schedulers[scheduler]
-        txt2img_obj = Text2ImagePipeline.from_pretrained(
-            scheduler=scheduler_obj,
-            import_mlir=args.import_mlir,
-            model_id=args.hf_model_id,
-            ckpt_loc=args.ckpt_loc,
-            precision=args.precision,
-            max_length=args.max_length,
-            batch_size=args.batch_size,
-            height=args.height,
-            width=args.width,
-            use_base_vae=args.use_base_vae,
-            use_tuned=args.use_tuned,
-            custom_vae=args.custom_vae,
-            low_cpu_mem_usage=args.low_cpu_mem_usage,
-            debug=args.import_debug if args.import_mlir else False,
-            use_lora=use_lora,
+        global_obj.set_sd_obj(
+            Text2ImagePipeline.from_pretrained(
+                scheduler=scheduler_obj,
+                import_mlir=args.import_mlir,
+                model_id=args.hf_model_id,
+                ckpt_loc=args.ckpt_loc,
+                precision=args.precision,
+                max_length=args.max_length,
+                batch_size=args.batch_size,
+                height=args.height,
+                width=args.width,
+                use_base_vae=args.use_base_vae,
+                use_tuned=args.use_tuned,
+                custom_vae=args.custom_vae,
+                low_cpu_mem_usage=args.low_cpu_mem_usage,
+                debug=args.import_debug if args.import_mlir else False,
+                use_lora=use_lora,
+            )
         )
 
-    txt2img_obj.scheduler = schedulers[scheduler]
+    global_obj.set_schedulers(schedulers[scheduler])
 
     start_time = time.time()
-    txt2img_obj.log = ""
+    global_obj.get_sd_obj().log = ""
     generated_imgs = []
     seeds = []
     img_seed = utils.sanitize_seed(seed)
     for i in range(batch_count):
         if i > 0:
             img_seed = utils.sanitize_seed(-1)
-        out_imgs = txt2img_obj.generate_images(
+        out_imgs = global_obj.get_sd_obj().generate_images(
             prompt,
             negative_prompt,
             batch_size,
@@ -178,8 +172,8 @@ def txt2img_inf(
         save_output_img(out_imgs[0], img_seed)
         generated_imgs.extend(out_imgs)
         seeds.append(img_seed)
-        txt2img_obj.log += "\n"
-        yield generated_imgs, generated_imgs[0], txt2img_obj.log
+        global_obj.get_sd_obj().log += "\n"
+        yield generated_imgs, generated_imgs[0], global_obj.get_sd_obj().log
 
     total_time = time.time() - start_time
     text_output = f"prompt={args.prompts}"

--- a/apps/stable_diffusion/web/index.py
+++ b/apps/stable_diffusion/web/index.py
@@ -5,6 +5,7 @@ if sys.platform == "darwin":
     os.environ["DYLD_LIBRARY_PATH"] = "/usr/local/lib"
 
 import gradio as gr
+import apps.stable_diffusion.web.utils.global_obj as global_obj
 from apps.stable_diffusion.src import args, clear_all
 from apps.stable_diffusion.web.utils.gradio_configs import (
     clear_gradio_tmp_imgs_folder,
@@ -52,6 +53,9 @@ from apps.stable_diffusion.web.ui import (
     outpaint_sendto_img2img,
     outpaint_sendto_inpaint,
 )
+
+# init global sd pipeline and config
+global_obj.init()
 
 
 def register_button_click(button, selectedid, inputs, outputs):

--- a/apps/stable_diffusion/web/ui/utils.py
+++ b/apps/stable_diffusion/web/ui/utils.py
@@ -4,6 +4,23 @@ from apps.stable_diffusion.src import get_available_devices
 import glob
 from pathlib import Path
 from apps.stable_diffusion.src import args
+from dataclasses import dataclass
+
+
+@dataclass
+class Config:
+    mode: str
+    model_id: str
+    ckpt_loc: str
+    precision: str
+    batch_size: int
+    max_length: int
+    height: int
+    width: int
+    device: str
+    use_lora: str
+    use_stencil: str
+
 
 custom_model_filetypes = (
     "*.ckpt",
@@ -35,6 +52,7 @@ predefined_models = [
     "stabilityai/stable-diffusion-2-1-base",
     "CompVis/stable-diffusion-v1-4",
 ]
+
 predefined_paint_models = [
     "runwayml/stable-diffusion-inpainting",
     "stabilityai/stable-diffusion-2-inpainting",

--- a/apps/stable_diffusion/web/utils/global_obj.py
+++ b/apps/stable_diffusion/web/utils/global_obj.py
@@ -1,0 +1,46 @@
+import gc
+
+
+"""
+The global objects include SD pipeline and config.
+Maintaining the global objects would avoid creating extra pipeline objects when switching modes.
+Also we could avoid memory leak when switching models by clearing the cache.
+"""
+
+
+def init():
+    global sd_obj
+    global config_obj
+    sd_obj = None
+    config_obj = None
+
+
+def set_sd_obj(value):
+    global sd_obj
+    sd_obj = value
+
+
+def set_cfg_obj(value):
+    global config_obj
+    config_obj = value
+
+
+def set_schedulers(value):
+    global sd_obj
+    sd_obj.scheduler = value
+
+
+def get_sd_obj():
+    return sd_obj
+
+
+def get_cfg_obj():
+    return config_obj
+
+
+def clear_cache():
+    global sd_obj
+    global config_obj
+    del sd_obj
+    del config_obj
+    gc.collect()


### PR DESCRIPTION
Using the global objects instead of creating one for each mode, so it won't create extra pipeline object when switching modes. Also clearing the cache when switching models to avoid memory leak.