### PR TITLE
Unload clip and workaround the memory leak for ondemand

### DIFF
--- a/apps/stable_diffusion/scripts/img2img.py
+++ b/apps/stable_diffusion/scripts/img2img.py
@@ -170,7 +170,8 @@ def img2img_inf(
         use_stencil=use_stencil,
     )
     if (
-        not global_obj.get_sd_obj()
+        args.ondemand
+        or not global_obj.get_sd_obj()
         or global_obj.get_cfg_obj() != new_config_obj
     ):
         global_obj.clear_cache()
@@ -239,6 +240,7 @@ def img2img_inf(
             )
 
     global_obj.set_sd_scheduler(args.scheduler)
+    global_obj.set_sd_ondemand(args.ondemand)
 
     start_time = time.time()
     global_obj.get_sd_obj().log = ""

--- a/apps/stable_diffusion/scripts/inpaint.py
+++ b/apps/stable_diffusion/scripts/inpaint.py
@@ -103,7 +103,8 @@ def inpaint_inf(
         use_stencil=None,
     )
     if (
-        not global_obj.get_sd_obj()
+        args.ondemand
+        or not global_obj.get_sd_obj()
         or global_obj.get_cfg_obj() != new_config_obj
     ):
         global_obj.clear_cache()
@@ -148,6 +149,7 @@ def inpaint_inf(
         )
 
     global_obj.set_sd_scheduler(scheduler)
+    global_obj.set_sd_ondemand(args.ondemand)
 
     start_time = time.time()
     global_obj.get_sd_obj().log = ""

--- a/apps/stable_diffusion/scripts/outpaint.py
+++ b/apps/stable_diffusion/scripts/outpaint.py
@@ -65,6 +65,9 @@ def outpaint_inf(
     args.steps = steps
     args.scheduler = scheduler
     args.img_path = "not none"
+    if ondemand:
+        print("Outpainting is not supporting ondemand yet.")
+        ondemand = False
     args.ondemand = ondemand
 
     # set ckpt_loc and hf_model_id.

--- a/apps/stable_diffusion/scripts/upscaler.py
+++ b/apps/stable_diffusion/scripts/upscaler.py
@@ -103,7 +103,8 @@ def upscaler_inf(
         use_stencil=None,
     )
     if (
-        not global_obj.get_sd_obj()
+        args.ondemand
+        or not global_obj.get_sd_obj()
         or global_obj.get_cfg_obj() != new_config_obj
     ):
         global_obj.clear_cache()
@@ -146,6 +147,7 @@ def upscaler_inf(
     global_obj.get_sd_obj().low_res_scheduler = global_obj.get_scheduler(
         "DDPM"
     )
+    global_obj.set_sd_ondemand(args.ondemand)
 
     start_time = time.time()
     global_obj.get_sd_obj().log = ""

--- a/apps/stable_diffusion/src/pipelines/pipeline_shark_stable_diffusion_outpaint.py
+++ b/apps/stable_diffusion/src/pipelines/pipeline_shark_stable_diffusion_outpaint.py
@@ -539,8 +539,6 @@ class OutpaintPipeline(StableDiffusionPipeline):
                     cpu_scheduling=cpu_scheduling,
                 )
                 all_imgs.extend(imgs)
-            if self.ondemand:
-                self.unload_vae()
 
             res_img = all_imgs[0].resize(
                 (image_to_process.width, image_to_process.height)

--- a/apps/stable_diffusion/src/pipelines/pipeline_shark_stable_diffusion_utils.py
+++ b/apps/stable_diffusion/src/pipelines/pipeline_shark_stable_diffusion_utils.py
@@ -153,7 +153,8 @@ class StableDiffusionPipeline:
         clip_inf_start = time.time()
         text_embeddings = self.text_encoder("forward", (text_input,))
         clip_inf_time = (time.time() - clip_inf_start) * 1000
-        # self.unload_clip()
+        if self.ondemand:
+            self.unload_clip()
         self.log += f"\nClip Inference time (ms) = {clip_inf_time:.3f}"
 
         return text_embeddings
@@ -410,7 +411,8 @@ class StableDiffusionPipeline:
 
         # SHARK: Report clip inference time
         clip_inf_time = (time.time() - clip_inf_start) * 1000
-        # self.unload_clip()
+        if self.ondemand:
+            self.unload_clip()
         self.log += f"\nClip Inference time (ms) = {clip_inf_time:.3f}"
 
         return text_embeddings.numpy()

--- a/apps/stable_diffusion/web/ui/txt2img_ui.py
+++ b/apps/stable_diffusion/web/ui/txt2img_ui.py
@@ -107,7 +107,8 @@ def txt2img_inf(
         use_stencil=None,
     )
     if (
-        not global_obj.get_sd_obj()
+        args.ondemand
+        or not global_obj.get_sd_obj()
         or global_obj.get_cfg_obj() != new_config_obj
     ):
         global_obj.clear_cache()
@@ -153,6 +154,7 @@ def txt2img_inf(
         )
 
     global_obj.set_sd_scheduler(scheduler)
+    global_obj.set_sd_ondemand(args.ondemand)
 
     start_time = time.time()
     global_obj.get_sd_obj().log = ""

--- a/apps/stable_diffusion/web/utils/global_obj.py
+++ b/apps/stable_diffusion/web/utils/global_obj.py
@@ -32,6 +32,11 @@ def set_sd_status(value):
     _sd_obj.status = value
 
 
+def set_sd_ondemand(value):
+    global _sd_obj
+    _sd_obj.ondemand = value
+
+
 def set_cfg_obj(value):
     global _config_obj
     _config_obj = value


### PR DESCRIPTION
- Enable unloading clip on demand
- Workaround the memory leak of unloading models (It still keeps something in memory after unloading models and using gc would cause error. I think something is still referenced so it can't be cleaned. The workaround is creating the SD pipeline everytime if on demand.)
- Disable unloading models for outpainting becuase it would load and unload models for each direction