### PR TITLE
[SD] Fix img2img API bug for custom_vae argument

### DIFF
--- a/apps/stable_diffusion/web/ui/img2img_ui.py
+++ b/apps/stable_diffusion/web/ui/img2img_ui.py
@@ -309,6 +309,7 @@ def img2img_api(
         hf_model_id=InputData["hf_model_id"]
         if "hf_model_id" in InputData.keys()
         else "stabilityai/stable-diffusion-2-1-base",
+        custom_vae="None",
         precision="fp16",
         device=available_devices[0],
         max_length=64,


### PR DESCRIPTION
-- https://github.com/nod-ai/SHARK/pull/1314 misses to add `custom_vae` parameter to img2img_if's invocation within img2img_api.
-- This commit adds a fix to the same.

Signed-off-by: Abhishek Varma <abhishek@nod-labs.com>