### PR TITLE
Don't dump image data on img2img api call.

### DIFF
--- a/apps/stable_diffusion/web/ui/img2img_ui.py
+++ b/apps/stable_diffusion/web/ui/img2img_ui.py
@@ -290,7 +290,9 @@ def encode_pil_to_base64(images):
 def img2img_api(
     InputData: dict,
 ):
-    print(InputData)
+    print(
+        f'Prompt: {InputData["prompt"]}, Negative Prompt: {InputData["negative_prompt"]}, Seed: {InputData["seed"]}'
+    )
     init_image = decode_base64_to_image(InputData["init_images"][0])
     res = img2img_inf(
         InputData["prompt"],


### PR DESCRIPTION
Currently when using the SD API, we print the entire input data dict which dumps the very long, non-human readable input image data.
Simplify the print statement such that prompt, negative prompt, and seed are printed exclusively.