### PR TITLE
Update txt2img_ui.py

### DIFF
--- a/apps/stable_diffusion/web/ui/txt2img_ui.py
+++ b/apps/stable_diffusion/web/ui/txt2img_ui.py
@@ -205,7 +205,7 @@ def txt2img_inf(
         else:
             save_output_img(out_imgs[0], img_seed)
             generated_imgs.extend(out_imgs)
-            yield generated_imgs, text_output, status_label(
+            #yield generated_imgs, text_output, status_label(
                 "Text-to-Image", i + 1, batch_count, batch_size
             )
 


### PR DESCRIPTION
Issue: 
-txt2img api is not working properly because there is a yield statement in the txt2img_inf function 
-there is also a yield statement in img2img_inf that was commented out 

Changes:
-commenting out the yield statement in the txt2img_inf function fixes the issue with the txt2img api (was returning a generator object before)