### PR TITLE
UI/Web: Fix upscaler stop button (mostly)

### DIFF
--- a/apps/stable_diffusion/web/ui/upscaler_ui.py
+++ b/apps/stable_diffusion/web/ui/upscaler_ui.py
@@ -564,5 +564,6 @@ with gr.Blocks(title="Upscaler") as upscaler_web:
         )
         generate_click = stable_diffusion.click(**status_kwargs).then(**kwargs)
         stop_batch.click(
-            fn=cancel_sd, cancels=[prompt_submit, neg_prompt_submit, generate_click]
+            fn=cancel_sd,
+            cancels=[prompt_submit, neg_prompt_submit, generate_click],
         )


### PR DESCRIPTION
Addresses issue https://github.com/nod-ai/SHARK/issues/1472

Changes:

* Hooks the cancel_sd function up to the Stop button on the upscaler tab.
* Adds checks for SD_STATE_CANCEL in the upscaler ui inference function.
* Sets and checks for SD_STATE_IDLE, SD_STATE_CANCEL in the upscaler pipeline in similar places to the non-upscaler pipeline (as in utils).

Known problems:

* If you press 'stop' on the upscaler tab, the next time you 'generate' on that tab it will be ignored, you need to press it again for the upscaler task to be triggered. No idea what is causing this.