### PR TITLE
[SD] (RDNA2) Enable new tuning for sd1.4

### DIFF
--- a/apps/stable_diffusion/src/utils/sd_annotation.py
+++ b/apps/stable_diffusion/src/utils/sd_annotation.py
@@ -125,7 +125,7 @@ def load_lower_configs(base_model_id=None):
                 config_name = f"{args.annotation_model}_v2_1_768_{args.precision}_{device}.json"
             else:
                 config_name = f"{args.annotation_model}_{version}_{args.precision}_{device}.json"
-        elif spec in ["rdna2"] and version in ["v2_1", "v2_1base"]:
+        elif spec in ["rdna2"] and version in ["v2_1", "v2_1base", "v1_4"]:
             config_name = f"{args.annotation_model}_{version}_{args.precision}_{device}_{spec}_{args.width}x{args.height}.json"
         else:
             config_name = f"{args.annotation_model}_{version}_{args.precision}_{device}_{spec}.json"

--- a/apps/stable_diffusion/src/utils/utils.py
+++ b/apps/stable_diffusion/src/utils/utils.py
@@ -347,6 +347,7 @@ def set_init_device_flags():
         not in [
             "stabilityai/stable-diffusion-2-1",
             "stabilityai/stable-diffusion-2-1-base",
+            "CompVis/stable-diffusion-v1-4",
         ]
     ):
         args.use_tuned = False


### PR DESCRIPTION
config located at [gs://shark_tank/sd_tuned_configs/unet_v1_4_fp16_vulkan_rdna2_512x512.json](https://console.cloud.google.com/storage/browser/_details/shark_tank/sd_tuned_configs/unet_v1_4_fp16_vulkan_rdna2_512x512.json;tab=live_object)

```
Loading Winograd config file from  C:\Users\ean\.local/shark_tank/configs\unet_winograd_vulkan.json
100%|████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 107/107 [00:00<00:00, 1.60kB/s]
100%|████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 107/107 [00:00<00:00, 3.20kB/s]
Loading lowering config file from  C:\Users\ean\.local/shark_tank/configs\unet_v1_4_fp16_vulkan_rdna2_512x512.json
100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 21.1k/21.1k [00:00<00:00, 185kB/s]
100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 21.1k/21.1k [00:00<00:00, 647kB/s]
Applying tuned configs on unet_1_64_512_512_fp16_tuned_cyberrealistic_v14_vulkan
No vmfb found. Compiling and saving to C:\V\SHARK\apps\stable_diffusion\web\unet_1_64_512_512_fp16_tuned_cyberrealistic_v14_vulkan.vmfb
Configuring for device:vulkan://00000000-0c00-0000-0000-000000000000
Using target triple -iree-vulkan-target-triple=rdna2-unknown-windows from command line args
Saved vmfb in C:\V\SHARK\apps\stable_diffusion\web\unet_1_64_512_512_fp16_tuned_cyberrealistic_v14_vulkan.vmfb.
50it [00:09,  5.19it/s]
No vmfb found. Compiling and saving to C:\V\SHARK\apps\stable_diffusion\web\vae_1_64_512_512_fp16_tuned_cyberrealistic_v14_vulkan.vmfb
Configuring for device:vulkan://00000000-0c00-0000-0000-000000000000
Using target triple -iree-vulkan-target-triple=rdna2-unknown-windows from command line args
Saved vmfb in C:\V\SHARK\apps\stable_diffusion\web\vae_1_64_512_512_fp16_tuned_cyberrealistic_v14_vulkan.vmfb.
50it [00:09,  5.13it/s]
50it [00:09,  5.18it/s]
50it [00:09,  5.21it/s]
50it [00:09,  5.40it/s]
50it [00:09,  5.27it/s]
50it [00:09,  5.19it/s]
50it [00:09,  5.32it/s]
50it [00:09,  5.17it/s]
50it [00:09,  5.14it/s]
```

untuned:
```
50it [00:13,  3.63it/s]
```