### PR TITLE
Prevent having no cuda devices for LLM breaking the UI

### DIFF
--- a/apps/stable_diffusion/web/ui/stablelm_ui.py
+++ b/apps/stable_diffusion/web/ui/stablelm_ui.py
@@ -115,13 +115,17 @@ with gr.Blocks(title="Chatbot") as stablelm_chat:
                 "TheBloke/vicuna-7B-1.1-HF",
             ],
         )
-        cuda_devices = [
+        supported_devices = [
             device for device in available_devices if "cuda" in device
         ]
+        enabled = len(supported_devices) > 0
         device = gr.Dropdown(
             label="Device",
-            value=cuda_devices[0],
-            choices=cuda_devices,
+            value=supported_devices[0]
+            if enabled
+            else "Only CUDA Supported for now",
+            choices=supported_devices,
+            interactive=enabled,
         )
     chatbot = gr.Chatbot().style(height=500)
     with gr.Row():
@@ -130,12 +134,13 @@ with gr.Blocks(title="Chatbot") as stablelm_chat:
                 label="Chat Message Box",
                 placeholder="Chat Message Box",
                 show_label=False,
+                interactive=enabled,
             ).style(container=False)
         with gr.Column():
             with gr.Row():
-                submit = gr.Button("Submit")
-                stop = gr.Button("Stop")
-                clear = gr.Button("Clear")
+                submit = gr.Button("Submit", interactive=enabled)
+                stop = gr.Button("Stop", interactive=enabled)
+                clear = gr.Button("Clear", interactive=enabled)
     system_msg = gr.Textbox(
         start_message, label="System Message", interactive=False, visible=False
     )


### PR DESCRIPTION
### Motivation/Changes

https://github.com/nod-ai/SHARK/commit/8c219604861a2b9a349fe645d91e253022256f93 broke UI/Web on startup as it doesn't take into account the fact that it is possible for ones machine to not have any cuda devices.

This handles that case.

### Possible Problems

* Since I don't have any cuda devices, I haven't tested whether this does what we want when you do, although it should if https://github.com/nod-ai/SHARK/commit/8c219604861a2b9a349fe645d91e253022256f93 was correct there.
* Blocks both vircuna and stabilitylm if no cuda. I don't know whether this is correct for stabilitylm.



