### PR TITLE
Fix unet512 always being used when --max_length=77

### DIFF
--- a/apps/stable_diffusion/src/pipelines/pipeline_shark_stable_diffusion_utils.py
+++ b/apps/stable_diffusion/src/pipelines/pipeline_shark_stable_diffusion_utils.py
@@ -222,7 +222,7 @@ class StableDiffusionPipeline:
         latent_history = [latents]
         text_embeddings = torch.from_numpy(text_embeddings).to(dtype)
         text_embeddings_numpy = text_embeddings.detach().numpy()
-        if text_embeddings.shape[1] <= 64:
+        if text_embeddings.shape[1] <= self.model_max_length:
             self.load_unet()
         else:
             self.load_unet_512()
@@ -244,7 +244,7 @@ class StableDiffusionPipeline:
 
             # Profiling Unet.
             profile_device = start_profiling(file_path="unet.rdc")
-            if text_embeddings.shape[1] <= 64:
+            if text_embeddings.shape[1] <= self.model_max_length:
                 noise_pred = self.unet(
                     "forward",
                     (
@@ -447,7 +447,7 @@ class StableDiffusionPipeline:
             # uncond_embeddings = uncond_embeddings.view(bs_embed * num_images_per_prompt, seq_len, -1)
             text_embeddings = torch.cat([uncond_embeddings, text_embeddings])
 
-        if text_embeddings.shape[1] > 64:
+        if text_embeddings.shape[1] > model_max_length:
             pad = (0, 0) * (len(text_embeddings.shape) - 2)
             pad = pad + (0, 512 - text_embeddings.shape[1])
             text_embeddings = torch.nn.functional.pad(text_embeddings, pad)


### PR DESCRIPTION
### Motivation

I was not getting the same images using the same parameter info, before and after https://github.com/nod-ai/SHARK/commit/b20411356344e3810eb1bce29f2689ebaad8723b was merged.

It seems that when you specify `--max_length=77`, unet512 is *always* used, and that, in combination whatever adjustments are then made to the processing of prompt embedding so that they can be passed in to that unet version, results in different images.

This does not happen with the default of `--max_length=64`.

### Changes

* Switches a few places in the SD pipeline, where an assumption of max_length=64 was being made, over to using the actual max_length as passed into the pipeline. This prevents unet512 and the accompanying prompt always being used when `--max_length=77`

### Possible Problems/Concerns

* I don't know whether we would expect `unet512` to give the same results as `unet` when given the same prompt that falls below `max_length`. If we do, this doesn't fix that.
* ~~I haven't tested any prompts that should trigger the use of unet512, as I haven't previously used any and don't have any to hand for comparison.~~ Checked with some long prompts from Civitai, the unet512 is used when the prompt is long and the images look the same with and without this commit.