### PR TITLE
Fix bert training

### DIFF
--- a/shark/backward_makefx.py
+++ b/shark/backward_makefx.py
@@ -15,7 +15,7 @@
 import torch
 from torch._decomp import get_decompositions
 from torch.fx.experimental.proxy_tensor import make_fx
-from torch.nn.utils import _stateless
+from torch.nn.utils import stateless
 
 from torch import fx
 import tempfile

--- a/shark/examples/shark_training/bert_training.py
+++ b/shark/examples/shark_training/bert_training.py
@@ -1,5 +1,5 @@
 import torch
-from torch.nn.utils import _stateless
+from torch.nn.utils import stateless
 from transformers import AutoTokenizer, AutoModelForSequenceClassification
 from shark.shark_trainer import SharkTrainer
 
@@ -33,7 +33,7 @@ inp = (torch.randint(2, (1, 128)),)
 
 def forward(params, buffers, args):
     params_and_buffers = {**params, **buffers}
-    _stateless.functional_call(
+    stateless.functional_call(
         mod, params_and_buffers, args, {}
     ).sum().backward()
     optim = torch.optim.SGD(get_sorted_params(params), lr=0.01)

--- a/shark/shark_importer.py
+++ b/shark/shark_importer.py
@@ -516,7 +516,6 @@ def import_with_fx(
         model,
         decomposition_table=get_decompositions(
             [
-                torch.ops.aten.embedding_dense_backward,
                 torch.ops.aten.native_layer_norm_backward,
                 torch.ops.aten.slice_backward,
                 torch.ops.aten.select_backward,


### PR DESCRIPTION
We don't need to use the upstream PyTorch decomposition for the op `aten.embedding_dense_backward`, since now we have the lowering for the same in Torch-MLIR (https://github.com/llvm/torch-mlir/pull/2255).