### PR TITLE
UI/App - Allow text selection of non-inputs in app mode

### DIFF
--- a/apps/stable_diffusion/web/index.py
+++ b/apps/stable_diffusion/web/index.py
@@ -30,7 +30,11 @@ def launch_app(address):
     width = window.winfo_screenwidth()
     height = window.winfo_screenheight()
     webview.create_window(
-        "SHARK AI Studio", url=address, width=width, height=height
+        "SHARK AI Studio",
+        url=address,
+        width=width,
+        height=height,
+        text_select=True,
     )
     webview.start(private_mode=False)
 


### PR DESCRIPTION
### Motivation

Running in app mode, you can't select any text that isn't part of an input control. This makes parameter info on the output gallery a lot less useful since you can't copy and paste it. This is different from how things work in web mode.

### Changes

* When defining the webview window for App mode, set it up to allow text selection, as disallowing it is the default.