### PR TITLE
UI/Web: Reduce animation of default --progress_bars setting to improve speed

### DIFF
--- a/apps/stable_diffusion/web/ui/css/sd_dark_theme.css
+++ b/apps/stable_diffusion/web/ui/css/sd_dark_theme.css
@@ -231,6 +231,16 @@ footer {
     display: none;
 }
 
+/* reduced animation load when generating */
+.generating {
+    animation-play-state: paused !important;
+}
+
+/* better clarity when progress bars are minimal */
+.meta-text {
+    background-color: var(--block-label-background-fill);
+}
+
 /* output gallery tab */
 .output_parameters_dataframe tbody td {
     font-size: small;

--- a/apps/stable_diffusion/web/ui/img2img_ui.py
+++ b/apps/stable_diffusion/web/ui/img2img_ui.py
@@ -650,7 +650,7 @@ with gr.Blocks(title="Image-to-Image") as img2img_web:
                 ondemand,
             ],
             outputs=[img2img_gallery, std_output, img2img_status],
-            show_progress=args.progress_bar,
+            show_progress="minimal" if args.progress_bar else "none",
         )
 
         status_kwargs = dict(

--- a/apps/stable_diffusion/web/ui/inpaint_ui.py
+++ b/apps/stable_diffusion/web/ui/inpaint_ui.py
@@ -550,7 +550,7 @@ with gr.Blocks(title="Inpainting") as inpaint_web:
                 ondemand,
             ],
             outputs=[inpaint_gallery, std_output, inpaint_status],
-            show_progress=args.progress_bar,
+            show_progress="minimal" if args.progress_bar else "none",
         )
         status_kwargs = dict(
             fn=lambda bc, bs: status_label("Inpaint", 0, bc, bs),

--- a/apps/stable_diffusion/web/ui/lora_train_ui.py
+++ b/apps/stable_diffusion/web/ui/lora_train_ui.py
@@ -215,7 +215,7 @@ with gr.Blocks(title="Lora Training") as lora_train_web:
                 ),
             ],
             outputs=[std_output],
-            show_progress=args.progress_bar,
+            show_progress="minimal" if args.progress_bar else "none",
         )
 
         prompt_submit = prompt.submit(**kwargs)

--- a/apps/stable_diffusion/web/ui/outpaint_ui.py
+++ b/apps/stable_diffusion/web/ui/outpaint_ui.py
@@ -578,7 +578,7 @@ with gr.Blocks(title="Outpainting") as outpaint_web:
                 ondemand,
             ],
             outputs=[outpaint_gallery, std_output, outpaint_status],
-            show_progress=args.progress_bar,
+            show_progress="minimal" if args.progress_bar else "none",
         )
         status_kwargs = dict(
             fn=lambda bc, bs: status_label("Outpaint", 0, bc, bs),

--- a/apps/stable_diffusion/web/ui/txt2img_ui.py
+++ b/apps/stable_diffusion/web/ui/txt2img_ui.py
@@ -524,7 +524,7 @@ with gr.Blocks(title="Text-to-Image") as txt2img_web:
                 ondemand,
             ],
             outputs=[txt2img_gallery, std_output, txt2img_status],
-            show_progress=args.progress_bar,
+            show_progress="minimal" if args.progress_bar else "none",
         )
 
         status_kwargs = dict(

--- a/apps/stable_diffusion/web/ui/upscaler_ui.py
+++ b/apps/stable_diffusion/web/ui/upscaler_ui.py
@@ -554,7 +554,7 @@ with gr.Blocks(title="Upscaler") as upscaler_web:
                 ondemand,
             ],
             outputs=[upscaler_gallery, std_output, upscaler_status],
-            show_progress=args.progress_bar,
+            show_progress="minimal" if args.progress_bar else "none",
         )
         status_kwargs = dict(
             fn=lambda bc, bs: status_label("Upscaler", 0, bc, bs),


### PR DESCRIPTION
Addresses #1457 

### Motivation

There is small but noticeable difference in generation speed between running with the UI minimized and with it not, in favor of the minimized case. This is also seen if you size the app or browser window such that the gallery showing generated images is outside the browser viewport. 

In addition, currently the `no-progress_bars` command-line option doesn't appear to improve speed after the first image in the batch, I'm guess something changed with the upgrade to gradio 3.34.0 there.

All these looks like they are being caused by the two CSS animations that are run by gradio during generation, the 'sweep across the gallery' animation you get during the first image generation of a batch, and the 'pulsing border' animation you get on both the gallery and the generation status text box. This latter one happens even when you have `--no-progress_bars` set.


### Code Changes

* Use the "minimal" setting for show_progress in gradio functions when the (currently default) --progress_bars option is set. This removes the 'sweep across the gallery' animation. You still get the textual progress indicator in the top right corner of the gallery.
* Remove the pulsation animation from the border of galleries and generation status textboxes for both --progress_bars and --no_progress_bars settings. The orange color is retained.

### Measured Generation Speed Changes

All these are using the same prompt and other settings from the UI using SharkEulerDiscrete, on an SD 1.5 based model, `ui=web`, Firefox browser on Windows 10:

Txt2Imge **without** changes:

```
h768 x w512 (--progress_bar)
50it [00:04, 10.02it/s]
50it [00:04, 10.03it/s]
50it [00:04, 10.01it/s]
50it [00:04, 10.02it/s]
50it [00:04, 10.01it/s]
50it [00:05,  9.97it/s]

h768 x w512 (--no-progress_bar)
50it [00:04, 10.34it/s]
50it [00:05,  9.98it/s]
50it [00:05,  9.95it/s]
50it [00:05,  9.93it/s]
50it [00:05,  9.96it/s]
50it [00:05,  9.93it/s]
```

Txt2Img **with** changes:

```
h768 x w512 (--progress_bar)

50it [00:04, 10.28it/s]
50it [00:04, 10.31it/s]
50it [00:04, 10.31it/s]
50it [00:04, 10.30it/s]
50it [00:04, 10.31it/s]
50it [00:04, 10.32it/s]

h768 x w512 (--no-progress_bar)

50it [00:04, 10.28it/s]
50it [00:04, 10.29it/s]
50it [00:04, 10.27it/s]
50it [00:04, 10.26it/s]
50it [00:04, 10.27it/s]
50it [00:04, 10.29it/s]
```
