### PR TITLE
UI/Web Output gallery - add 'open folder' button (needs Mac/Linux testing)

### DIFF
--- a/apps/stable_diffusion/web/ui/css/sd_dark_theme.css
+++ b/apps/stable_diffusion/web/ui/css/sd_dark_theme.css
@@ -247,7 +247,7 @@ footer {
     line-height: var(--line-xs)
 }
 
-#output_refresh_button {
+.output_icon_button {
     max-width: 30px;
     align-self: end;
     padding-bottom: 8px;

--- a/apps/stable_diffusion/web/ui/outputgallery_ui.py
+++ b/apps/stable_diffusion/web/ui/outputgallery_ui.py
@@ -1,6 +1,8 @@
 import glob
 import gradio as gr
 import os
+import subprocess
+import sys
 from PIL import Image
 
 from apps.stable_diffusion.src import args
@@ -94,7 +96,7 @@ with gr.Blocks() as outputgallery_web:
         with gr.Column(scale=4):
             with gr.Box():
                 with gr.Row():
-                    with gr.Column(scale=16, min_width=160):
+                    with gr.Column(scale=15, min_width=160):
                         subdirectories = gr.Dropdown(
                             label=f"Subdirectories of {output_dir}",
                             type="value",
@@ -103,7 +105,19 @@ with gr.Blocks() as outputgallery_web:
                             interactive=True,
                         ).style(container=False)
                     with gr.Column(
-                        scale=1, min_width=32, elem_id="output_refresh_button"
+                        scale=1,
+                        min_width=32,
+                        elem_classes="output_icon_button",
+                    ):
+                        open_subdir = gr.Button(
+                            variant="secondary",
+                            value="\U0001F5C1",  # unicode open folder
+                            interactive=False,
+                        ).style(size="sm")
+                    with gr.Column(
+                        scale=1,
+                        min_width=32,
+                        elem_classes="output_icon_button",
                     ):
                         refresh = gr.Button(
                             variant="secondary",
@@ -192,6 +206,17 @@ with gr.Blocks() as outputgallery_web:
             ),
         ]
 
+    def on_open_subdir(subdir):
+        subdir_path = os.path.normpath(os.path.join(output_dir, subdir))
+
+        if os.path.isdir(subdir_path):
+            if sys.platform == "linux":
+                subprocess.run(["xdg-open", subdir_path])
+            elif sys.platform == "darwin":
+                subprocess.run(["open", subdir_path])
+            elif sys.platform == "win32":
+                os.startfile(subdir_path)
+
     def on_refresh(current_subdir: str) -> list:
         # get an up-to-date subdirectory list
         refreshed_subdirs = output_subdirs()
@@ -266,10 +291,16 @@ with gr.Blocks() as outputgallery_web:
         params = displayable_metadata(filename)
 
         if params:
-            return [
-                filename,
-                list(map(list, params["parameters"].items())),
-            ]
+            if params["source"] == "missing":
+                return [
+                    "Could not find this image file, refresh the gallery and update the images",
+                    [["Status", "File missing"]],
+                ]
+            else:
+                return [
+                    filename,
+                    list(map(list, params["parameters"].items())),
+                ]
 
         return [
             filename,
@@ -299,9 +330,13 @@ with gr.Blocks() as outputgallery_web:
     # that might have created since the application was started. Doing it
     # this way means a browser refresh/reload always gets the most
     # up-to-date data.
-    def on_select_tab(subdir_paths):
+    def on_select_tab(subdir_paths, request: gr.Request):
+        local_client = request.headers["host"].startswith(
+            "127.0.0.1:"
+        ) or request.headers["host"].startswith("localhost:")
+
         if len(subdir_paths) == 0:
-            return on_refresh("")
+            return on_refresh("") + [gr.update(interactive=local_client)]
         else:
             return (
                 # Change nothing, (only untyped gr.update() does this)
@@ -310,13 +345,14 @@ with gr.Blocks() as outputgallery_web:
                 gr.update(),
                 gr.update(),
                 gr.update(),
+                gr.update(),
             )
 
-    # Unfortunately as of gradio 3.22.0 gr.update against Galleries
-    # doesn't support things set with .style, nor the elem_classes kwarg, so
-    # we have to directly set things up via JavaScript if we want the client
-    # to take notice of our changes to the number of columns after it
-    # decides to put them back to the original number when we change something
+    # Unfortunately as of gradio 3.34.0 gr.update against Galleries doesn't
+    # support things set with .style, nor the elem_classes kwarg, so we have
+    # to directly set things up via JavaScript if we want the client to take
+    # notice of our changes to the number of columns after it decides to put
+    # them back to the original number when we change something
     def js_set_columns_in_browser(timeout_length):
         return f"""
             (new_cols) => {{
@@ -379,6 +415,10 @@ with gr.Blocks() as outputgallery_web:
         queue=False,
     ).then(**set_gallery_columns_immediate)
 
+    open_subdir.click(
+        on_open_subdir, inputs=[subdirectories], queue=False
+    ).then(**set_gallery_columns_immediate)
+
     refresh.click(**clear_gallery).then(
         on_refresh,
         [subdirectories],
@@ -417,6 +457,7 @@ with gr.Blocks() as outputgallery_web:
                 gallery_files,
                 gallery,
                 logo,
+                open_subdir,
             ],
             queue=False,
         ).then(**set_gallery_columns_immediate)

--- a/apps/stable_diffusion/web/utils/metadata/display.py
+++ b/apps/stable_diffusion/web/utils/metadata/display.py
@@ -8,6 +8,9 @@ from .format import compact, humanize
 
 
 def displayable_metadata(image_filename: str) -> dict:
+    if not os.path.isfile(image_filename):
+        return {"source": "missing", "parameters": {}}
+
     pil_image = Image.open(image_filename)
 
     # we have PNG generation parameters (preferred, as it's what the txt2img dropzone reads,

--- a/apps/stable_diffusion/web/utils/metadata/format.py
+++ b/apps/stable_diffusion/web/utils/metadata/format.py
@@ -91,6 +91,18 @@ def compact(metadata: dict) -> dict:
         else:
             result["Hires resize"] = f"{hires_y}x{hires_x}"
 
+    # remove VAE if it exists and is empty
+    if (result.keys() & {"VAE"}) and (
+        not result["VAE"] or result["VAE"] == "None"
+    ):
+        result.pop("VAE")
+
+    # remove LoRA if it exists and is empty
+    if (result.keys() & {"LoRA"}) and (
+        not result["LoRA"] or result["LoRA"] == "None"
+    ):
+        result.pop("LoRA")
+
     return result
 
 


### PR DESCRIPTION
_This contains code for Mac and Linux which I have not tested so I don't know is correct. Plus the whole concept feels pretty half-assed to me, but then again I keep running from the branch I have it on and **using** the thing. And continually rebasing it. Soooo PR._ 

### Motivation 

It would be useful to be able to mark images in the output gallery and then filter them in or out of the gallery. Also at some stage move the ones you don't want somewhere else so they can be deleted (or move the ones you want to keep somewhere else, so you can delete what's left). I was trying to think of the simplest ways to do that whilst having the filtering persist between runs, and one of the ways I thought of was 'having marking an image move it to another subdirectory, and unmarking it move it back'.

This is not that.

This is 'Well if you're thinking of faffing about shuffling files around like that, you might as well just throw up your hands and put in a ~expletive~ button that opens the current subdir in the os file browser if you're running the UI on the same machine Shark is running, have them do it manually, and expect them to hit refresh we they're done. Wait! is that even possible?'

Apparently yes.

### Changes

* Adds a button that opens the currently selected subdirectory using the default OS file manager if the http request is from 127.0.0.1 or localhost.
* Improves output gallery handling of having images deleted out from under it.
* Don't show VAE or LoRA lines in output gallery parameter info panel when their value is 'None'

### Problems/Concerns

* I've written code to do this for Windows, Mac and Linux. I don't know that what I've written works at all on Mac or Linux. So probably DNM until someone who can test those has done so.
* In Windows the first time you use in a session it the File Explorer flashes discretely to let you know it wants attention rather than immediately popping up the window.
* Entirely useless if you're not on the same machine as the the browser.
* Doesn't really solve the original filtering problem, because you still have to find the files you want muck about with in os file browser even tho' it is pointing at the right directory, and then you have to refresh once you're done, and... 🤷 

