### PR TITLE
UI/Web Refix remaining gradio deprecation warning

### DIFF
--- a/apps/stable_diffusion/web/ui/outputgallery_ui.py
+++ b/apps/stable_diffusion/web/ui/outputgallery_ui.py
@@ -119,7 +119,8 @@ with gr.Blocks() as outputgallery_web:
                             variant="secondary",
                             value="\U0001F5C1",  # unicode open folder
                             interactive=False,
-                        ).style(size="sm")
+                            size="sm",
+                        )
                     with gr.Column(
                         scale=1,
                         min_width=32,


### PR DESCRIPTION
### Motivation

I regressed one of fixes for gradio deprecations, whilst resolving a merge conflict with https://github.com/nod-ai/SHARK/pull/1634


### Changes

* Refix the remaining gradio deprecation warning in output gallery I regressed when resolving a merge conflict.