### PR TITLE
Pyinstaller Path Patch

### DIFF
--- a/apps/stable_diffusion/shark_sd.spec
+++ b/apps/stable_diffusion/shark_sd.spec
@@ -1,5 +1,5 @@
 # -*- mode: python ; coding: utf-8 -*-
-from apps.stable_diffusion.shark_studio_imports import datas, hiddenimports
+from apps.stable_diffusion.shark_studio_imports import pathex, datas, hiddenimports
 
 binaries = []
 
@@ -7,7 +7,7 @@ block_cipher = None
 
 a = Analysis(
     ['web/index.py'],
-    pathex=['.'],
+    pathex=pathex,
     binaries=binaries,
     datas=datas,
     hiddenimports=hiddenimports,

--- a/apps/stable_diffusion/shark_studio_imports.py
+++ b/apps/stable_diffusion/shark_studio_imports.py
@@ -6,6 +6,9 @@ import sys
 
 sys.setrecursionlimit(sys.getrecursionlimit() * 5)
 
+# python path for pyinstaller
+pathex = [".", "./apps/language_models/langchain"]
+
 # datafiles for pyinstaller
 datas = []
 datas += collect_data_files("torch")

--- a/apps/stable_diffusion/studio_bundle.spec
+++ b/apps/stable_diffusion/studio_bundle.spec
@@ -1,5 +1,5 @@
 # -*- mode: python ; coding: utf-8 -*-
-from apps.stable_diffusion.shark_studio_imports import datas, hiddenimports
+from apps.stable_diffusion.shark_studio_imports import pathex, datas, hiddenimports
 
 binaries = []
 
@@ -7,7 +7,7 @@ block_cipher = None
 
 a = Analysis(
     ['web\\index.py'],
-    pathex=['.'],
+    pathex=pathex,
     binaries=binaries,
     datas=datas,
     hiddenimports=hiddenimports,


### PR DESCRIPTION
Pyinstaller was failing with some import erros as the [langchain PR](https://github.com/nod-ai/SHARK/pull/1657/files) assumes that the root is the langchain folder. This is not an issue when running outside of exe because of [this line](https://github.com/nod-ai/SHARK/blob/ab01f0f048ee9b8cd4fea463461f148bf0904d17/apps/language_models/langchain/gen.py#L28). However, it does not have the intended effect in pyinstaller.