### PR TITLE
UI/Web: Reorder tabs to separate/group SD, LLM and Experimental

### DIFF
--- a/apps/stable_diffusion/web/index.py
+++ b/apps/stable_diffusion/web/index.py
@@ -221,16 +221,8 @@ if __name__ == "__main__":
                 outpaint_web.render()
             with gr.TabItem(label="Upscaler", id=4):
                 upscaler_web.render()
-            with gr.TabItem(label="Model Manager", id=5):
-                model_web.render()
-            with gr.TabItem(label="Chat Bot(Experimental)", id=6):
-                stablelm_chat.render()
-            with gr.TabItem(label="LoRA Training(Experimental)", id=7):
-                lora_train_web.render()
-            with gr.TabItem(label="MultiModal (Experimental)", id=8):
-                minigpt4_web.render()
             if args.output_gallery:
-                with gr.TabItem(label="Output Gallery", id=9) as og_tab:
+                with gr.TabItem(label="Output Gallery", id=5) as og_tab:
                     outputgallery_web.render()
 
                 # extra output gallery configuration
@@ -244,6 +236,14 @@ if __name__ == "__main__":
                         upscaler_status,
                     ]
                 )
+            with gr.TabItem(label="Model Manager", id=6):
+                model_web.render()
+            with gr.TabItem(label="LoRA Training (Experimental)", id=8):
+                lora_train_web.render()
+            with gr.TabItem(label="Chat Bot (Experimental)", id=7):
+                stablelm_chat.render()
+            with gr.TabItem(label="MultiModal (Experimental)", id=9):
+                minigpt4_web.render()
             with gr.TabItem(label="DocuChat(Experimental)", id=10):
                 h2ogpt_web.render()
 


### PR DESCRIPTION
### Motivation

With all the new tabs, the order of them has gotten into a bit of a tangle. This tries to tidy things up a bit.

### Changes

* Move `Output gallery` tab immediately after `Upscaler`.
* Move `LoRA Training` to be the first of the experimental tabs after `Model Manager`.
* This keeps the tabs relating to SD together (assuming Model Manager is SD), the Experimental Tabs together, and the LLM tabs together.

### Problems/Concerns

* Conflicts with [#1700](https://github.com/nod-ai/SHARK/pull/1700) which adds...Yet another tab.
* I was tempted to add the `(Experimental)` tag to the Model Manager given its current state. But I didn't.

