### PR TITLE
Unsharded Vicuna: Fix Memory Error compiling mlir for lmsys/vicuna-7b-v1.3 fp16 with 64 GiB

### DIFF
--- a/apps/language_models/scripts/vicuna.py
+++ b/apps/language_models/scripts/vicuna.py
@@ -1,6 +1,7 @@
 import argparse
 import json
 import re
+import gc
 from io import BytesIO
 from pathlib import Path
 from tqdm import tqdm
@@ -39,9 +40,6 @@ from shark.shark_inference import SharkInference
 
 from brevitas_examples.llm.llm_quant.quantize import quantize_model
 from brevitas_examples.llm.llm_quant.run_utils import get_model_impl
-
-if __name__ == "__main__":
-    import gc
 
 
 parser = argparse.ArgumentParser(
@@ -114,11 +112,18 @@ parser.add_argument(
     "--cache_vicunas",
     default=False,
     action=argparse.BooleanOptionalAction,
-    help="For debugging purposes, creates a first_{precision}.mlir and second_{precision}.mlir and stores on disk"
+    help="For debugging purposes, creates a first_{precision}.mlir and second_{precision}.mlir and stores on disk",
 )
 
 
-def brevitas〇matmul_rhs_group_quant〡shape(lhs: List[int], rhs: List[int], rhs_scale: List[int], rhs_zero_point: List[int], rhs_bit_width: int, rhs_group_size: int) -> List[int]:
+def brevitas〇matmul_rhs_group_quant〡shape(
+    lhs: List[int],
+    rhs: List[int],
+    rhs_scale: List[int],
+    rhs_zero_point: List[int],
+    rhs_bit_width: int,
+    rhs_group_size: int,
+) -> List[int]:
     if len(lhs) == 3 and len(rhs) == 2:
         return [lhs[0], lhs[1], rhs[0]]
     elif len(lhs) == 2 and len(rhs) == 2:
@@ -127,20 +132,30 @@ def brevitas〇matmul_rhs_group_quant〡shape(lhs: List[int], rhs: List[int], rh
         raise ValueError("Input shapes not supported.")
 
 
-def brevitas〇matmul_rhs_group_quant〡dtype(lhs_rank_dtype: Tuple[int, int], rhs_rank_dtype: Tuple[int, int], rhs_scale_rank_dtype: Tuple[int, int], rhs_zero_point_rank_dtype: Tuple[int, int], rhs_bit_width: int, rhs_group_size: int) -> int:
+def brevitas〇matmul_rhs_group_quant〡dtype(
+    lhs_rank_dtype: Tuple[int, int],
+    rhs_rank_dtype: Tuple[int, int],
+    rhs_scale_rank_dtype: Tuple[int, int],
+    rhs_zero_point_rank_dtype: Tuple[int, int],
+    rhs_bit_width: int,
+    rhs_group_size: int,
+) -> int:
     # output dtype is the dtype of the lhs float input
     lhs_rank, lhs_dtype = lhs_rank_dtype
     return lhs_dtype
 
 
-def brevitas〇matmul_rhs_group_quant〡has_value_semantics(lhs, rhs, rhs_scale, rhs_zero_point, rhs_bit_width, rhs_group_size) -> None:
+def brevitas〇matmul_rhs_group_quant〡has_value_semantics(
+    lhs, rhs, rhs_scale, rhs_zero_point, rhs_bit_width, rhs_group_size
+) -> None:
     return
 
 
 brevitas_matmul_rhs_group_quant_library = [
     brevitas〇matmul_rhs_group_quant〡shape,
     brevitas〇matmul_rhs_group_quant〡dtype,
-    brevitas〇matmul_rhs_group_quant〡has_value_semantics]
+    brevitas〇matmul_rhs_group_quant〡has_value_semantics,
+]
 
 
 class VicunaBase(SharkLLMBase):
@@ -176,11 +191,14 @@ class VicunaBase(SharkLLMBase):
         self, first_vicuna_mlir, second_vicuna_mlir, output_name
     ):
         print(f"[DEBUG] combining first and second mlir")
+        print(f"[DEBIG] output_name = {output_name}")
         maps1 = []
         maps2 = []
         constants = set()
         f1 = []
         f2 = []
+
+        print(f"[DEBUG] processing first vircuna mlir")
         first_vicuna_mlir = first_vicuna_mlir.splitlines()
         while first_vicuna_mlir:
             line = first_vicuna_mlir.pop(0)
@@ -193,6 +211,7 @@ class VicunaBase(SharkLLMBase):
                 f1.append(line)
         f1 = f1[:-1]
         del first_vicuna_mlir
+        gc.collect()
 
         for i, map_line in enumerate(maps1):
             map_var = map_line.split(" ")[0]
@@ -203,6 +222,7 @@ class VicunaBase(SharkLLMBase):
                 for func_line in f1
             ]
 
+        print(f"[DEBUG] processing second vircuna mlir")
         second_vicuna_mlir = second_vicuna_mlir.splitlines()
         while second_vicuna_mlir:
             line = second_vicuna_mlir.pop(0)
@@ -216,6 +236,8 @@ class VicunaBase(SharkLLMBase):
                 line = re.sub("forward", "second_vicuna_forward", line)
                 f2.append(line)
         f2 = f2[:-1]
+        del second_vicuna_mlir
+        gc.collect()
 
         for i, map_line in enumerate(maps2):
             map_var = map_line.split(" ")[0]
@@ -236,6 +258,7 @@ class VicunaBase(SharkLLMBase):
         global_var_loading1 = []
         global_var_loading2 = []
 
+        print(f"[DEBUG] processing constants")
         counter = 0
         constants = list(constants)
         while constants:
@@ -279,6 +302,7 @@ class VicunaBase(SharkLLMBase):
                 )
         new_f1, new_f2 = [], []
 
+        print(f"[DEBUG] processing f1")
         for line in f1:
             if "func.func" in line:
                 new_f1.append(line)
@@ -287,6 +311,7 @@ class VicunaBase(SharkLLMBase):
             else:
                 new_f1.append(line)
 
+        print(f"[DEBUG] processing f2")
         for line in f2:
             if "func.func" in line:
                 new_f2.append(line)
@@ -305,27 +330,43 @@ class VicunaBase(SharkLLMBase):
 
         f1 = new_f1
         f2 = new_f2
+
+        del new_f1
+        del new_f2
+        gc.collect()
+
         print(
             [
                 "c20_i64 = arith.addi %dim_i64, %c1_i64 : i64" in x
                 for x in [maps1, maps2, global_vars, f1, f2]
             ]
         )
-        whole_string = "\n".join(
-            maps1
-            + maps2
-            + [module_start]
-            + global_vars
-            + f1
-            + f2
-            + [module_end]
-        )
 
-        f_ = open(output_name, "w+")
-        f_.write(whole_string)
-        f_.close()
+        # doing it this way rather than assembling the whole string
+        # to prevent OOM with 64GiB RAM when encoding the file.
 
-        return whole_string
+        print(f"[DEBUG] Saving mlir to {output_name}")
+        with open(output_name, "w+") as f_:
+            f_.writelines(line + "\n" for line in maps1)
+            f_.writelines(line + "\n" for line in maps2)
+            f_.writelines(line + "\n" for line in [module_start])
+            f_.writelines(line + "\n" for line in global_vars)
+            f_.writelines(line + "\n" for line in f1)
+            f_.writelines(line + "\n" for line in f2)
+            f_.writelines(line + "\n" for line in [module_end])
+
+        del maps1
+        del maps2
+        del module_start
+        del global_vars
+        del f1
+        del f2
+        del module_end
+        gc.collect()
+
+        print(f"[DEBUG] Reading combined mlir back in")
+        with open(output_name, "rb") as f:
+            return f.read()
 
     def generate_new_token(self, params, sharded=True):
         is_first = params["is_first"]
@@ -983,7 +1024,7 @@ class UnshardedVicuna(VicunaBase):
         low_device_memory=False,
         weight_group_size=128,
         download_vmfb=False,
-        cache_vicunas=False,
+        cache_vicunas=True,
     ) -> None:
         super().__init__(model_name, hf_model_path, max_num_tokens)
         if "llama2" in self.model_name and hf_auth_token == None:
@@ -1182,11 +1223,10 @@ class UnshardedVicuna(VicunaBase):
                 else:
                     compilation_prompt = "".join(["0" for _ in range(17)])
 
-
-                if Path(f'first_{self.precision}.mlir').exists():
+                if Path(f"first_{self.precision}.mlir").exists():
                     print(f"loading first_{self.precision}.mlir")
                     with open(Path(f"first_{self.precision}.mlir"), "r") as f:
-                      first_module = f.read()
+                        first_module = f.read()
                 else:
                     # generate first vicuna
                     compilation_input_ids = self.tokenizer(
@@ -1251,6 +1291,9 @@ class UnshardedVicuna(VicunaBase):
                             verbose=False,
                         )
                     del ts_graph
+                    del firstVicunaCompileInput
+                    gc.collect()
+
                     print(
                         "[DEBUG] successfully generated first vicuna linalg mlir"
                     )
@@ -1335,6 +1378,8 @@ class UnshardedVicuna(VicunaBase):
                             verbose=False,
                         )
                     del ts_graph
+                    del secondVicunaCompileInput
+                    gc.collect()
                     print(
                         "[DEBUG] successfully generated second vicuna linalg mlir"
                     )
@@ -1381,7 +1426,6 @@ class UnshardedVicuna(VicunaBase):
 
     def generate(self, prompt, cli=True):
         # TODO: refactor for cleaner integration
-        import gc
         if self.shark_model is None:
             self.compile()
         res_tokens = []


### PR DESCRIPTION
### Motivation

I get a Memory Error writing the combined MLIR file inside the Python text encoding IO code. Presumably an OOM since it heavily hits the page file with my 64GiB of system memory.

This is on Windows 10, run through the UI on, with `lmsys/vicuna-7b-v1.3`, fp16, and vulkan selected.

These changes get me all the way through IREE compile which then falls over complaining about a constant redefinition.

### Changes

* in `combine_mlir_scripts` since we're writing a file anyway, read the file back in to get the return value, so we don't have to have another copy assembled in memory whilst writing the file.
* In `combine_mlir_scripts` write the file out line by line from the individual source vars instead of writing everything at once to reduce memory pressure when python does text encoding,
* In `combine_mlir_scripts` use del and gc.collect() more aggressively.
* Outside `combine_mlir_scripts` add more del and gc.collect statements in the unsharded vicuna compile code to try and reduce memory pressure for when we call that function.

### Problems Concerns

* Do we even care about unsharded these days?
* Probably slower if you have 128GiB of system memory, and its already slow.
* Some of the additional `del`s and `gc.collect`s probably aren't doing anything, they are all 'well that looks reasonable to me' placements, rather than having done any profiling.
* Haven't tried with the TheBloke/vicuna version of the model. Don't know whether it had this problem.