### PR TITLE
[WIP] Windows Autoupdate Mechanism

### DIFF
--- a/apps/stable_diffusion/web/index.py
+++ b/apps/stable_diffusion/web/index.py
@@ -40,23 +40,24 @@ def launch_app(address):
     )
     webview.start(private_mode=False)
 
+
 # In Windows MSI ONLY
 def install_updates():
-    '''Installs update from latest release on GitHub if currently running on Windows MSI and an update exists'''
+    """Installs update from latest release on GitHub if currently running on Windows MSI and an update exists"""
 
     # Ensures that code is running in a pyinstaller bundle on windows
-    if sys.platform != 'win32' or not getattr(sys, 'frozen', False):
+    if sys.platform != "win32" or not getattr(sys, "frozen", False):
         return
-    
+
     # Gets path to updater.exe
     application_path = os.path.dirname(sys.executable)
     application_path, _ = os.path.split(application_path)
-    application_path = os.path.join(application_path, 'updater.exe')
+    application_path = os.path.join(application_path, "updater.exe")
 
     # If updater exe does not exist, do nothing
     if not os.path.isfile(application_path):
         return
-    
+
     # run updater.exe
     subprocess.run(application_path)
 

--- a/apps/stable_diffusion/web/index.py
+++ b/apps/stable_diffusion/web/index.py
@@ -1,6 +1,7 @@
 from multiprocessing import Process, freeze_support
 import os
 import sys
+import subprocess
 
 if sys.platform == "darwin":
     # import before IREE to avoid torch-MLIR library issues
@@ -39,10 +40,34 @@ def launch_app(address):
     )
     webview.start(private_mode=False)
 
+# In Windows MSI ONLY
+def install_updates():
+    '''Installs update from latest release on GitHub if currently running on Windows MSI and an update exists'''
+
+    # Ensures that code is running in a pyinstaller bundle on windows
+    if sys.platform != 'win32' or not getattr(sys, 'frozen', False):
+        return
+    
+    # Gets path to updater.exe
+    application_path = os.path.dirname(sys.executable)
+    application_path, _ = os.path.split(application_path)
+    application_path = os.path.join(application_path, 'updater.exe')
+
+    # If updater exe does not exist, do nothing
+    if not os.path.isfile(application_path):
+        return
+    
+    # run updater.exe
+    subprocess.run(application_path)
+
 
 if __name__ == "__main__":
     # required to do multiprocessing in a pyinstaller freeze
     freeze_support()
+
+    # install updates if running in windows
+    install_updates()
+
     if args.api or "api" in args.ui.split(","):
         from apps.stable_diffusion.web.ui import (
             txt2img_api,


### PR DESCRIPTION
For when we start distributing the Advanced Installer MSI:

- Shark Studio will run the updater.exe script to check and install upgrades
- This PR ensures that this only happens in Windows MSI installations

@powderluv should I keep the auto-update function in index.py or move it to a new file eg. `update.py` since we might have more update functions when we support Mac?