### PR TITLE
fixes for pydantic in gpt_langchain.py

### DIFF
--- a/apps/language_models/langchain/gpt_langchain.py
+++ b/apps/language_models/langchain/gpt_langchain.py
@@ -436,7 +436,7 @@ class GradioInference(LLM):
     chat_client: bool = False
 
     return_full_text: bool = True
-    stream: bool = False
+    stream_output: bool = Field(False, alias="stream")
     sanitize_bot_response: bool = False
 
     prompter: Any = None
@@ -481,7 +481,7 @@ class GradioInference(LLM):
         # so server should get prompt_type or '', not plain
         # This is good, so gradio server can also handle stopping.py conditions
         # this is different than TGI server that uses prompter to inject prompt_type prompting
-        stream_output = self.stream
+        stream_output = self.stream_output
         gr_client = self.client
         client_langchain_mode = "Disabled"
         client_langchain_action = LangChainAction.QUERY.value
@@ -596,7 +596,7 @@ class H2OHuggingFaceTextGenInference(HuggingFaceTextGenInference):
     inference_server_url: str = ""
     timeout: int = 300
     headers: dict = None
-    stream: bool = False
+    stream_output: bool = Field(False, alias="stream")
     sanitize_bot_response: bool = False
     prompter: Any = None
     tokenizer: Any = None
@@ -663,7 +663,7 @@ class H2OHuggingFaceTextGenInference(HuggingFaceTextGenInference):
         # lower bound because client is re-used if multi-threading
         self.client.timeout = max(300, self.timeout)
 
-        if not self.stream:
+        if not self.stream_output:
             res = self.client.generate(
                 prompt,
                 **gen_server_kwargs,
@@ -852,7 +852,7 @@ def get_llm(
                 top_p=top_p,
                 # typical_p=top_p,
                 callbacks=callbacks if stream_output else None,
-                stream=stream_output,
+                stream_output=stream_output,
                 prompter=prompter,
                 tokenizer=tokenizer,
                 client=hf_client,


### PR DESCRIPTION
### Motivation

Just before a686d7d89f55bb0d5f918a995df1ed98e7e9e73a which temporarily disabled DocuChat/langchain I was getting the following error, when running the ui/web after manually installing the `langchain` dependency:

```
Traceback (most recent call last):
  File "C:\develop\SHARK\apps\stable_diffusion\web\index.py", line 94, in <module>
    from apps.stable_diffusion.web.ui.utils import create_custom_models_folders
  File "C:\develop\SHARK\apps\stable_diffusion\web\ui\__init__.py", line 82, in <module>
    from apps.stable_diffusion.web.ui.h2ogpt import h2ogpt_upload, h2ogpt_web
  File "C:\develop\SHARK\apps\stable_diffusion\web\ui\h2ogpt.py", line 15, in <module>
    from gpt_langchain import (
  File "C:\develop\SHARK\apps\language_models\langchain\gpt_langchain.py", line 418, in <module>
    class GradioInference(LLM):
  File "pydantic\main.py", line 186, in pydantic.main.ModelMetaclass.__new__
  File "pydantic\utils.py", line 167, in pydantic.utils.validate_field_name

NameError: Field name "stream" shadows a BaseModel attribute; use a different field name with "alias='stream'".
```

Possibly DNM, because I don't know how relevant this is in real life.


### Changes

- Follow the advice in the above error and change 'stream' instance variables to 'stream_output' and aliased them back to 'stream' to clear clash with Pydantic BaseModel.

### Problems/Concerns

- May not be relevant with this disabled.
- May have been a dependency issue on my part.
- My first use of `pydantic` was on an internal work project *today*, so I'm not familiar with it *at all*.