### PR TITLE
add support passing iree flags for  LLMs

### DIFF
--- a/apps/stable_diffusion/web/ui/stablelm_ui.py
+++ b/apps/stable_diffusion/web/ui/stablelm_ui.py
@@ -180,6 +180,15 @@ def chat(
                 print("unrecognized device")
 
             max_toks = 128 if model_name == "codegen" else 512
+
+            # get iree flags that need to be overridden, from commandline args
+            _extra_args = []
+            # vulkan target triple
+            if args.iree_vulkan_target_triple != "":
+                _extra_args.append(
+                    f"-iree-vulkan-target-triple={args.iree_vulkan_target_triple}"
+                )
+
             if model_name == "vicuna4":
                 vicuna_model = ShardedVicuna(
                     model_name,
@@ -188,6 +197,7 @@ def chat(
                     precision=precision,
                     max_num_tokens=max_toks,
                     compressed=True,
+                    extra_args_cmd=_extra_args,
                 )
             else:
                 #  if config_file is None:
@@ -198,6 +208,7 @@ def chat(
                     device=device,
                     precision=precision,
                     max_num_tokens=max_toks,
+                    extra_args_cmd=_extra_args,
                 )
                 #  else:
                 #      if config_file is not None:


### PR DESCRIPTION
- required for passing target triple from command line when running LLMs on web and cli
- NOTE:
  - target triple for Sharded LLMs is experimental as of now.
  - duplicate args from SD and LLMs will need to be refactored into a more disjoint set of cli args to prevent the argparse objects from eating up each others values when used in the same file.

