### PR TITLE
Windows installer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -193,3 +193,8 @@ stencil_annotator/
 # For DocuChat
 apps/language_models/langchain/user_path/
 db_dir_UserData
+
+# Windows Installer Caches and Builds
+windows_installer/shark_studio-cache/
+windows_installer/shark_studio-SetupFiles/
+windows_installer/shark_updater-SetupFiles/

--- a/.gitignore
+++ b/.gitignore
@@ -198,3 +198,5 @@ db_dir_UserData
 windows_installer/shark_studio-cache/
 windows_installer/shark_studio-SetupFiles/
 windows_installer/shark_updater-SetupFiles/
+windows_installer/shark_studio.aip
+windows_installer/shark_updater.aip

--- a/windows_installer/build_installer.ps1
+++ b/windows_installer/build_installer.ps1
@@ -1,0 +1,64 @@
+param (
+    # Advanced Installer path in the computer
+    [Parameter(Mandatory=$true)]
+    [string]$ai_path,
+    # Version of MSI build
+    [Parameter(Mandatory=$true)]
+    [string]$version,
+    # Flag to indicate beta version
+    [switch]$beta
+)
+
+# Useful constants
+$project_path = "./windows_installer/shark_studio.aip"
+$updater_path = "./windows_installer/shark_updater.aip"
+$project_files_path = -join($(pwd),"\dist\studio_bundle")
+
+# These variables are affected by beta flag
+$update_info_url = "https://github.com/nod-ai/SHARK/releases/latest/download/shark_updater.txt"
+$update_msi_url = "https://github.com/nod-ai/SHARK/releases/latest/download/shark_studio.msi"
+$msi_path = ".\windows_installer\shark_studio-SetupFiles\shark_studio.msi"
+
+if ($beta) {
+    $update_info_url = "https://github.com/nod-ai/SHARK/releases/download/latest-nightly/shark_updater_beta.txt"
+    $update_msi_url = "https://github.com/nod-ai/SHARK/releases/download/latest-nightly/shark_studio_beta.msi"
+    $msi_path = ".\windows_installer\shark_studio-SetupFiles\shark_studio_beta.msi"
+}
+
+
+# Assuming pyinstaller has already been run
+
+# Configures AIP to latest version of ./dist/studio_bundle
+Write-Host "removing old files and shortcuts"
+&$ai_path /edit $project_path /DelShortcut -name "Shark Studio" -dir "SHORTCUTDIR"
+&$ai_path /edit $project_path /DelFolder "APPDIR\studio_bundle"
+
+Write-Host "adding new files and shortcuts"
+&$ai_path /edit $project_path /AddFolder "APPDIR" $project_files_path
+&$ai_path /edit $project_path /NewShortcut -name "Shark Studio" -target "APPDIR\studio_bundle\studio_bundle.exe" -dir "SHORTCUTDIR" -runasadmin -pin_to_taskbar
+
+Write-Host "setting version to $version"
+&$ai_path /edit $project_path /SetVersion $version
+
+# Sets update url based on beta flag
+&$ai_path /edit $project_path /SetUpdatesUrl $update_info_url
+
+# Builds the msi
+&$ai_path /rebuild $project_path
+
+# Renames the msi if beta flag is on (TODO)
+if ($beta) {
+    Rename-Item -Path "./windows_installer/shark_studio-SetupFiles/shark_studio.msi" -NewName "shark_studio_beta.msi"
+}
+
+# Resets to latest msi
+&$ai_path /edit $updater_path /DeleteUpdate Update
+&$ai_path /edit $updater_path /NewUpdate $msi_path -name Update -display_name "shark_update" -url $update_msi_url
+
+# builds shark_updater.txt
+&$ai_path /rebuild $updater_path
+
+# Renames shark_updater.txt if beta flag is on
+if ($beta) {
+    Rename-Item -Path "./windows_installer/shark_updater-SetupFiles/shark_updater.txt" -NewName "shark_updater_beta.txt"
+}

--- a/windows_installer/shark_updater.aip
+++ b/windows_installer/shark_updater.aip
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<DOCUMENT Type="Advanced Installer" CreateVersion="20.9.1" version="20.9.1" Modules="update" Language="en" Id="{1203EC4C-90A2-417F-9E14-6CC649A9AC51}">
+  <COMPONENT cid="caphyon.advinst.msicomp.DictionaryComponent">
+    <ROW Path="&lt;AI_DICTS&gt;aiu-ue.ail"/>
+    <ROW Path="&lt;AI_DICTS&gt;aiu-ue_en.ail"/>
+  </COMPONENT>
+  <COMPONENT cid="caphyon.advinst.msicomp.UpdaterEditorComponent">
+    <ROW Section="Update" Key="Name" Value="shark_update"/>
+    <ROW Section="Update" Key="ProductVersion" Value="1.0.0" ValueLocId="-"/>
+    <ROW Section="Update" Key="URL" Value="https://github.com/nod-ai/SHARK/releases/latest/download/shark_studio.msi" ValueLocId="-"/>
+    <ROW Section="Update" Key="Size" Value=".\windows_installer\shark_studio-SetupFiles\shark_studio.msi" ValueLocId="-"/>
+    <ROW Section="Update" Key="ReleaseDate" Value="22289" ValueLocId="-"/>
+    <ROW Section="Update" Key="SHA256" Value=".\windows_installer\shark_studio-SetupFiles\shark_studio.msi" ValueLocId="-"/>
+    <ROW Section="Update" Key="MD5" Value=".\windows_installer\shark_studio-SetupFiles\shark_studio.msi" ValueLocId="-"/>
+    <ROW Section="Update" Key="ServerFileName" Value="shark_studio.msi" ValueLocId="-"/>
+    <ROW Section="Update" Key="RegistryKey" Value="HKUD\Software\nod-ai\Shark Studio\Version" ValueLocId="-"/>
+    <ROW Section="Update" Key="Version" Value="1.0.0" ValueLocId="-"/>
+    <ATTRIBUTE name="OutputFileName" value=".txt"/>
+  </COMPONENT>
+</DOCUMENT>


### PR DESCRIPTION
Here's the PR for the windows installer. I tested on a fork and the autoupdate works as expected.
### Prerequisites
- Install Advanced Installer, register it with our license (Anush has this)
- Set up signing releases

### For Building MSI and update.txt
run `.\windows_installer\build_installer.ps1 -ai_path <path-to-advanced-installer> -version <symantic-version>`
for me it looks like `.\windows_installer\build_installer.ps1 -ai_path "C:\Program Files (x86)\Caphyon\Advanced Installer 20.9.1\bin\x86\AdvancedInstaller.com" -version 1.0.0`

This will create the MSI at `.\windows_installer\shark_studio-SetupFiles\shark_studio.msi` and the updater at `.\windows_installer\shark_updater-SetupFiles\shark_updater.msi`

Add these binaries to the nightly release. Nothing else has to be done because the updater will always point to whatever is labelled the latest stable (non-prerelease) version.

### For Building the Beta (Nightly) version
Run the aforementioned command with the `-beta` flag. 

This will create the MSI at `.\windows_installer\shark_studio-SetupFiles\shark_studio_beta.msi` and the updater at `.\windows_installer\shark_updater-SetupFiles\shark_updater_beta.msi`

Add these to the nightly build so users have access to older nightly versions. Also add these to a new release tag called `latest-nightly`. All nightly builds will update to whatever binaries are published under the `latest-nightly` tag.

### Concerns
The setup is somewhat funny because there exists state inside the aip files. I will create a google doc explaining this better.