### PR TITLE
fix llama2-70b rewrite tensor dim

### DIFF
--- a/apps/language_models/scripts/vicuna.py
+++ b/apps/language_models/scripts/vicuna.py
@@ -1369,7 +1369,7 @@ class UnshardedVicuna(VicunaBase):
         if "llama2_13b" in self.model_name:
             pkv_tensor_shape = "tensor<1x40x?x128x"
         elif "llama2_70b" in self.model_name:
-            pkv_tensor_shape = "tensor<1x60x?x128x"
+            pkv_tensor_shape = "tensor<1x8x?x128x"
         else:
             pkv_tensor_shape = "tensor<1x32x?x128x"
         if self.precision in ["fp16", "int4", "int8"]:


### PR DESCRIPTION
fixes the following error which occurs when on compilation of llama2_70b generated from vicuna.py

```
<stdin>:39854:25: error: use of value '%arg1' expects different type than prior uses: 'tensor<1x60x?x128xf16>' vs 'tensor<1x8x?x128xf16>'

%dim_4_int = tensor.dim %arg1, %c2 : tensor<1x60x?x128xf16>
```

