### PR TITLE
Add flag for specifying device-local caching allocator heap key.

### DIFF
--- a/apps/stable_diffusion/src/utils/stable_args.py
+++ b/apps/stable_diffusion/src/utils/stable_args.py
@@ -458,6 +458,14 @@ p.add_argument(
     help="Specify your own huggingface authentication tokens for models like Llama2.",
 )
 
+p.add_argument(
+    "--device_allocator_heap_key",
+    type=str,
+    default="",
+    help="Specify heap key for device caching allocator."
+    "Expected form: max_allocation_size;max_allocation_capacity;max_free_allocation_count"
+    "Example: --device_allocator_heap_key='*;1gib' (will limit caching on device to 1 gigabyte)",
+)
 ##############################################################################
 # IREE - Vulkan supported flags
 ##############################################################################

--- a/apps/stable_diffusion/src/utils/utils.py
+++ b/apps/stable_diffusion/src/utils/utils.py
@@ -184,11 +184,17 @@ def compile_through_fx(
 
 
 def set_iree_runtime_flags():
+    # TODO: This function should be device-agnostic and piped properly
+    # to general runtime driver init.
     vulkan_runtime_flags = get_iree_vulkan_runtime_flags()
     if args.enable_rgp:
         vulkan_runtime_flags += [
             f"--enable_rgp=true",
             f"--vulkan_debug_utils=true",
+        ]
+    if args.device_allocator_heap_key:
+        vulkan_runtime_flags += [
+            f"--device_allocator=caching:device_local={args.device_allocator_heap_key}",
         ]
     set_iree_vulkan_runtime_flags(flags=vulkan_runtime_flags)
 


### PR DESCRIPTION
This is really just a temporary solution to piping these kinds of IREE runtime options from SHARK Studio.
We should probably just allow the specification of `iree_runtime_args` to be piped down in a device-agnostic fashion instead of naming them here in stable_args or in shark_args (worse), though it does help to have a curated list of knobs to tweak for users.

Currently only piped through for Vulkan devices.

I have a better implementation of supplying runtime args to the core SHARK python runtime utils in progress here: https://github.com/nod-ai/SHARK/pull/1855 but it still needs some work.