### PR TITLE
(Studio) Collect pipeline submodules for diffusers ckpt preprocessing.

### DIFF
--- a/apps/stable_diffusion/shark_studio_imports.py
+++ b/apps/stable_diffusion/shark_studio_imports.py
@@ -74,6 +74,9 @@ datas += [
 # hidden imports for pyinstaller
 hiddenimports = ["shark", "shark.shark_inference", "apps"]
 hiddenimports += [x for x in collect_submodules("skimage") if "tests" not in x]
+hiddenimports += [
+    x for x in collect_submodules("diffusers") if "tests" not in x
+]
 blacklist = ["tests", "convert"]
 hiddenimports += [
     x


### PR DESCRIPTION
Adds diffusers submodules to hidden imports to force pyinstaller to pick up the SD pipeline modules needed for checkpoint preprocessing.