### PR TITLE
SD: Fix repeatable seeds consistency over different batch counts

### DIFF
--- a/apps/stable_diffusion/src/utils/utils.py
+++ b/apps/stable_diffusion/src/utils/utils.py
@@ -808,7 +808,7 @@ def batch_seeds(
         saved_random_state = random_getstate()
         if all(seed < 0 for seed in seeds):
             seeds[0] = sanitize_seed(seeds[0])
-        seed_random(str(seeds))
+        seed_random(str([n for n in seeds if n > -1]))
 
     # generate any seeds that are unspecified
     seeds = [sanitize_seed(seed) for seed in seeds]


### PR DESCRIPTION
## Motivation

With repeatable seeds selected, I ran a set of three batches of one image in Txt2Img, followed by a set of six batches of one image, using the same starting seed.

Images 2 and 3 of set 1 were not the same images as 2 and 3 of set 2, and were logged as having used different seeds.

Although each batch set of the same length with the same starting seeds generates the same sequence of seeds, batches of different lengths don't match up after the initial seed. This is not what I was expecting.

(I did this from the UI, but that shouldn't be significant)

## Changes

* Set the input seed for the random number generator when generating repeatable seeds to exclude any negative numbers in the parsed seed input including placeholder ones for subsequent batches.  This makes seeds generated for different batch counts consistent where they have the same input for the initial seed or set of seeds.

## Possible Problems/Concerns

* This changes exactly which seeds are generated for a set of batches when repeatable seeds is on from the previous code, so anything that relies on the previous sequences might have a problem.