### PR TITLE
SD: Fix repeatable seeds when initial seed should be random

### DIFF
--- a/apps/stable_diffusion/src/utils/utils.py
+++ b/apps/stable_diffusion/src/utils/utils.py
@@ -804,10 +804,11 @@ def batch_seeds(
     seeds = seeds[:batch_count] + [-1] * (batch_count - len(seeds))
 
     if repeatable:
-        # set seed for the rng based on what we have so far
-        saved_random_state = random_getstate()
         if all(seed < 0 for seed in seeds):
             seeds[0] = sanitize_seed(seeds[0])
+
+        # set seed for the rng based on what we have so far
+        saved_random_state = random_getstate()
         seed_random(str([n for n in seeds if n > -1]))
 
     # generate any seeds that are unspecified


### PR DESCRIPTION
### Motivation

I ran a set of batches with repeatable seeds set, with initial seed set to -1.
I then immediately afterward ran another set of batches with repeatable seeds set, again with the initial seed set to -1.

I expected to get a completely different set of images and seeds for each set of batches, because the initial seed generated for each set should have been different due to the -1 being replaced with a new random seed each time. However I got the exact same set of seeds and the same images.

The cause of this is that the rng state is being saved for repeatable seeds before the first seed is generated, rather than after.

(I did this from the UI, but that shouldn't make a difference)

### Changes

* When repeatable seeds is set, but only random seeds are requested, generate the initial seed before seeding the rng with it for the subsequent seeds, and only then save the rng state. This ensures that once the rng state is restored if another set of random seeds is requested immediately afterward, this new set will not start with the same same seed as the previous set.

### Possible Problems/Concerns

N/A