### PR TITLE
Fix MacOS web execution flow

### DIFF
--- a/apps/language_models/scripts/vicuna.py
+++ b/apps/language_models/scripts/vicuna.py
@@ -1303,6 +1303,7 @@ class UnshardedVicuna(VicunaBase):
 
     def get_model_path(self, suffix="mlir"):
         safe_device = self.device.split("-")[0]
+        safe_device = safe_device.split("://")[0]
         if suffix in ["mlirbc", "mlir"]:
             return Path(f"{self.model_name}_{self.precision}.{suffix}")
 

--- a/apps/stable_diffusion/src/utils/utils.py
+++ b/apps/stable_diffusion/src/utils/utils.py
@@ -477,7 +477,12 @@ def get_available_devices():
                         f"{device_name} => {driver_name.replace('local', 'cpu')}"
                     )
                 else:
-                    device_list.append(f"{device_name} => {driver_name}://{i}")
+                    # for drivers with single devices
+                    # let the default device be selected without any indexing
+                    if len(device_list_dict) == 1:
+                        device_list.append(f"{device_name} => {driver_name}")
+                    else:
+                        device_list.append(f"{device_name} => {driver_name}://{i}")
         return device_list
 
     set_iree_runtime_flags()

--- a/apps/stable_diffusion/src/utils/utils.py
+++ b/apps/stable_diffusion/src/utils/utils.py
@@ -482,7 +482,9 @@ def get_available_devices():
                     if len(device_list_dict) == 1:
                         device_list.append(f"{device_name} => {driver_name}")
                     else:
-                        device_list.append(f"{device_name} => {driver_name}://{i}")
+                        device_list.append(
+                            f"{device_name} => {driver_name}://{i}"
+                        )
         return device_list
 
     set_iree_runtime_flags()

--- a/apps/stable_diffusion/web/ui/stablelm_ui.py
+++ b/apps/stable_diffusion/web/ui/stablelm_ui.py
@@ -164,6 +164,8 @@ def chat(
         device = "vulkan"
     elif "rocm" in device:
         device = "rocm"
+    elif "metal" in device:
+        device = "metal"
     else:
         print("unrecognized device")
 
@@ -331,6 +333,8 @@ def llm_chat_api(InputData: dict):
         elif "vulkan" in device:
             device_id = int(device.split("://")[1])
             device = "vulkan"
+        elif "metal" in device:
+            device = "metal"
         else:
             print("unrecognized device")
 

--- a/apps/stable_diffusion/web/ui/stablelm_ui.py
+++ b/apps/stable_diffusion/web/ui/stablelm_ui.py
@@ -153,6 +153,7 @@ def chat(
 
     device_id = None
     model_name, model_path = list(map(str.strip, model.split("=>")))
+    device = device if "=>" not in device else device.split("=>")[1].strip()
     if "cuda" in device:
         device = "cuda"
     elif "sync" in device:

--- a/shark/iree_utils/compile_utils.py
+++ b/shark/iree_utils/compile_utils.py
@@ -632,7 +632,9 @@ def get_iree_runtime_config(device):
     haldevice = haldriver.create_device_by_uri(
         device,
         # metal devices have a failure with caching allocators atm. blcking this util it gets fixed upstream.
-        allocators=shark_args.device_allocator if "metal" not in device else None,
+        allocators=shark_args.device_allocator
+        if "metal" not in device
+        else None,
     )
     config = ireert.Config(device=haldevice)
     return config

--- a/shark/iree_utils/compile_utils.py
+++ b/shark/iree_utils/compile_utils.py
@@ -624,7 +624,7 @@ def get_results(
 def get_iree_runtime_config(device):
     device = iree_device_map(device)
     haldriver = ireert.get_driver(device)
-    if device == "metal" and shark_args.device_allocator == "caching":
+    if "metal" in device and shark_args.device_allocator == "caching":
         print(
             "[WARNING] metal devices can not have a `caching` allocator."
             "\nUsing default allocator `None`"
@@ -632,7 +632,7 @@ def get_iree_runtime_config(device):
     haldevice = haldriver.create_device_by_uri(
         device,
         # metal devices have a failure with caching allocators atm. blcking this util it gets fixed upstream.
-        allocators=shark_args.device_allocator if device != "metal" else None,
+        allocators=shark_args.device_allocator if "metal" not in device else None,
     )
     config = ireert.Config(device=haldevice)
     return config


### PR DESCRIPTION
- drivers with single device will not be shown with `://0` indexing
- plumb metal device through chatbot execution (currently the default metal device is selected)