### PR TITLE
SD - Fix civitai download on Windows +other civitai download improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -182,7 +182,7 @@ generated_imgs/
 
 # Custom model related artefacts
 variants.json
-models/
+/models/
 
 # models folder
 apps/stable_diffusion/web/models/

--- a/apps/stable_diffusion/src/utils/__init__.py
+++ b/apps/stable_diffusion/src/utils/__init__.py
@@ -41,3 +41,4 @@ from apps.stable_diffusion.src.utils.utils import (
     resize_stencil,
     _compile_module,
 )
+from apps.stable_diffusion.src.utils.civitai import get_civitai_checkpoint

--- a/apps/stable_diffusion/src/utils/civitai.py
+++ b/apps/stable_diffusion/src/utils/civitai.py
@@ -1,0 +1,42 @@
+import re
+import requests
+from apps.stable_diffusion.src.utils.stable_args import args
+
+from pathlib import Path
+from tqdm import tqdm
+
+
+def get_civitai_checkpoint(url: str):
+    with requests.get(url, allow_redirects=True, stream=True) as response:
+        response.raise_for_status()
+
+        # civitai api returns the filename in the content disposition
+        base_filename = re.findall(
+            '"([^"]*)"', response.headers["Content-Disposition"]
+        )[0]
+        destination_path = (
+            Path.cwd() / (args.ckpt_dir or "models") / base_filename
+        )
+
+        # we don't have this model downloaded yet
+        if not destination_path.is_file():
+            print(
+                f"downloading civitai model from {url} to {destination_path}"
+            )
+
+            size = int(response.headers["content-length"], 0)
+            progress_bar = tqdm(total=size, unit="iB", unit_scale=True)
+
+            with open(destination_path, "wb") as f:
+                for chunk in response.iter_content(chunk_size=65536):
+                    f.write(chunk)
+                    progress_bar.update(len(chunk))
+
+            progress_bar.close()
+
+        # we already have this model downloaded
+        else:
+            print(f"civitai model already downloaded to {destination_path}")
+
+        response.close()
+        return destination_path.as_posix()


### PR DESCRIPTION
### Motivation

While testing https://github.com/nod-ai/SHARK/pull/1906 I found that entering Civitai api download urls into the webui wasn't working for me. This was due to the code trying to launch a subprocess to `wget` which is not guaranteed to be (and probably isn't) installed on windows, so everything falls over there.

Once I had something working in Python to do the download instead, I discovered a number of other problems with the civitai download, mainly to do with naming being taken from the civitai id number rather than the correct filename of the model file.

This PR should address most of this.

### Changes

* Move civitai model download into Python code rather than make a subprocess call to wget, as wget usually won't exist on Windows.
* Save model files downloaded from civitai under the correct filename reported by civitai rather than their civitai index number. i.e. 'ghostmix_v20Bakedvae.safetensors' instead of '36520.safetensors'
* If it has been set, use args.chkpt_dir as the  destination folder when downloading from civitai. Only hardcode 'models' as the fallback.
* Set args.chkpt_loc after civitai download or name resolution so webui adds the correct model name to any metadata it writes for generated images.
* Use a stricter check for determining whether custom_weights are a civitai api download url.
* Update .gitignore to only exclude the root /models folder rather than all models folders (allows files in /apps/stable_diffusion/src/models/ to be committed without git whining)

### Problems/Concerns

* The webui should ideally update itself once a civitai download has occurred to show and list the correct .safetensors file replacing the civitai download url in its interface. This though is starting to get into 'precompile' rather than 'ondemand' area and I didn't want get into that level of pipeline/webui overhaul.
* Given the flakiness of civitai in general, more explicit error handling for when it has broken would be sensible. I haven't been sensible.
* There doesn't seem to be any alternative to poking the civitai download url to get the filename from the headers to check whether we already have the .safetensors file downloaded. This doesn't feel ideal.
* I'm not sure my .gitignore change is correct. It might be too general.