### PR TITLE
fix vicuna cli vulkan path

### DIFF
--- a/apps/language_models/scripts/vicuna.py
+++ b/apps/language_models/scripts/vicuna.py
@@ -1303,6 +1303,7 @@ class UnshardedVicuna(VicunaBase):
 
     def get_model_path(self, suffix="mlir"):
         safe_device = self.device.split("-")[0]
+        safe_device = safe_device.split("://")[0]
         if suffix in ["mlirbc", "mlir"]:
             return Path(f"{self.model_name}_{self.precision}.{suffix}")
 
@@ -1966,6 +1967,7 @@ if __name__ == "__main__":
             max_num_tokens=max_tokens,
             min_num_tokens=min_tokens,
             device=args.device,
+            vulkan_target_triple=vulkan_target_triple,
             precision=args.precision,
             vicuna_mlir_path=vic_mlir_path,
             vicuna_vmfb_path=vic_vmfb_path,

--- a/shark/iree_utils/compile_utils.py
+++ b/shark/iree_utils/compile_utils.py
@@ -39,7 +39,15 @@ def get_iree_device_args(device, extra_args=[]):
                 f"Specific device selection only supported for vulkan now."
                 f"Proceeding with {device} as device."
             )
-        device_num = device_uri[1]
+        # device_uri can be device_num or device_path.
+        # assuming number of devices for a single driver will be not be >99
+        if len(device_uri[1]) <= 2:
+            # expected to be device index in range 0 - 99
+            device_num = int(device_uri[1])
+        else:
+            # expected to be device path
+            device_num = device_uri[1]
+
     else:
         device_num = 0
 

--- a/shark/iree_utils/vulkan_utils.py
+++ b/shark/iree_utils/vulkan_utils.py
@@ -29,7 +29,6 @@ def get_all_vulkan_devices():
 
     driver = get_driver("vulkan")
     device_list_src = driver.query_available_devices()
-    device_list_src.sort(key=lambda d: d["path"])
     return [d["name"] for d in device_list_src]
 
 


### PR DESCRIPTION
- add fixes for device selection on vulkan
- also this removes the forced ordering of devices based on device_path and now relies on device ordering from iree to be consistent across reboots (user should ensure selecting the correct device index for the current session)