### PR TITLE
(Studio) Disable SD tunings and sub-model downloads

### DIFF
--- a/apps/stable_diffusion/src/utils/stable_args.py
+++ b/apps/stable_diffusion/src/utils/stable_args.py
@@ -331,7 +331,7 @@ p.add_argument(
 
 p.add_argument(
     "--use_tuned",
-    default=True,
+    default=False,
     action=argparse.BooleanOptionalAction,
     help="Download and use the tuned version of the model if available.",
 )

--- a/apps/stable_diffusion/src/utils/stable_args.py
+++ b/apps/stable_diffusion/src/utils/stable_args.py
@@ -308,7 +308,7 @@ p.add_argument(
 
 p.add_argument(
     "--import_mlir",
-    default=False,
+    default=True,
     action=argparse.BooleanOptionalAction,
     help="Imports the model from torch module to shark_module otherwise "
     "downloads the model from shark_tank.",


### PR DESCRIPTION
For stability, until these two features have been updated and are once again functional on nightly releases, disable UNet tunings to workaround linalg IR changes and disable shark_tank downloads until the turbine SD pipelines are set up and we can generate the correct artifacts for the updated stack.