### PR TITLE
UI: Output galllery cleanups

### DIFF
--- a/apps/stable_diffusion/web/ui/css/sd_dark_theme.css
+++ b/apps/stable_diffusion/web/ui/css/sd_dark_theme.css
@@ -247,9 +247,14 @@ footer {
 }
 
 /* output gallery tab */
+.output_parameters_dataframe table.table {
+    /* works around a gradio bug that always shows scrollbars */
+    overflow: clip auto;
+}
+
 .output_parameters_dataframe tbody td {
     font-size: small;
-    line-height: var(--line-xs)
+    line-height: var(--line-xs);
 }
 
 .output_icon_button {


### PR DESCRIPTION
### Motivation

The Gradio version we have pinned allows removal of my original crufty code to manage the number of gallery columns in the output gallery, but also needs a workaround for some inappropriate scrollbar visibility on the parameters pane on the same tab.

So this does that.

### Changes

* Workaround gradio bug that causes the parameters frame to always show scrollbars.
* Remove the original funky method of setting the number of image columns in the gallery using _fn= JavaScript events. The version of gradio we now have pinned allows doing this by setting the property on the gallery directly and also doesn't keep resetting the columns on other events being fired, so we no longer need to workaround that by re-setting the columns every time that happens.