### PR TITLE
Pin pydantic to 2.4.1 in requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -42,6 +42,7 @@ joblib # for langchain
 timm # for MiniGPT4
 langchain
 einops # for zoedepth
+pydantic==2.4.1 # pin until pyinstaller-hooks-contrib works with beta versions
 
 # Keep PyInstaller at the end. Sometimes Windows Defender flags it but most folks can continue even if it errors
 pefile


### PR DESCRIPTION
pyinstaller-hooks-contrib doesn't see beta versions of pydantic as versions greater than 2.0.0, and so it looks for an attribute `compile` only available in versions older than 2.0.0 if you have a beta version of pydantic.

This returns an error and causes the pyinstaller build to fail, so pin pydantic to 2.4.1 until the hook is fixed.