### PR TITLE
Re-enable SD tunings without matmuls.

### DIFF
--- a/apps/stable_diffusion/src/utils/stable_args.py
+++ b/apps/stable_diffusion/src/utils/stable_args.py
@@ -323,7 +323,7 @@ p.add_argument(
 
 p.add_argument(
     "--use_tuned",
-    default=False,
+    default=True,
     action=argparse.BooleanOptionalAction,
     help="Download and use the tuned version of the model if available.",
 )

--- a/shark/model_annotation.py
+++ b/shark/model_annotation.py
@@ -117,7 +117,7 @@ def walk_children(
             "mhlo.dot",
             "mhlo.dot_general",
             "mhlo.convolution",
-            "linalg.matmul",
+            # "linalg.matmul",
             "linalg.batch_matmul",
             "linalg.conv_2d_nhwc_hwcf",
             "linalg.generic",
@@ -181,7 +181,7 @@ def get_op_shape(op: ir.Operation, search_op: str):
             n = input2.split("tensor<")[1].split("x")[2]
             shape_list = [1, int(b), int(m), int(n), int(k)]
 
-    if search_op in ["matmul", "all"]:
+    if search_op in ["matmul"]:
         if op.name in ["mhlo.dot"]:
             op_result = str(op.results[0])
             m = op_result.split("tensor<")[1].split("x")[0]


### PR DESCRIPTION
It seems there is some lowering pass pipeline change for the matmul dispatches. Since the tunings for matmuls in SD is less performance-impactful than other ops, re-enable tunings for ops other than matmuls.

This bumps inference speed on my 7900xtx back up to ~22it/s