### PR TITLE
[vicuna.py] Rework benchmark statistics calculation

### DIFF
--- a/apps/language_models/scripts/vicuna.py
+++ b/apps/language_models/scripts/vicuna.py
@@ -2127,13 +2127,14 @@ if __name__ == "__main__":
         is_first = True
         token_times_ms = []
 
-        for text, msg, exec_time_ms in vic.generate(prompt, cli=True):
+        for text, msg, exec_time in vic.generate(prompt, cli=True):
             if msg is None:
                 if is_first:
-                    prefill_time_ms = exec_time_ms
+                    # Note that the prefill time is in seconds, and all the decoded tokens in ms.
+                    prefill_time_ms = exec_time * 1000
                     is_first = False
                 else:
-                    token_times_ms.append(exec_time_ms)
+                    token_times_ms.append(exec_time)
             elif "formatted" in msg:
                 history[-1][1] = text
                 print(f"\nResponse:\n{text.strip()}\n")

--- a/apps/language_models/scripts/vicuna.py
+++ b/apps/language_models/scripts/vicuna.py
@@ -1984,7 +1984,7 @@ def print_aggregate_stats(run_infos: list[BenchmarkRunInfo]) -> None:
         return
 
     if len(run_infos) == 1:
-        print(run_infos[0])
+        run_infos[0].print()
         return
 
     total_tokens = run_infos[0].num_prompt_tokens + run_infos[0].num_generated_tokens()

--- a/apps/language_models/scripts/vicuna.py
+++ b/apps/language_models/scripts/vicuna.py
@@ -1999,7 +1999,7 @@ def print_aggregate_stats(run_infos: list[BenchmarkRunInfo]) -> None:
     print(f"Prefill: avg. {avg_prefill_ms:.2f} ms (stdev {stdev_prefill:.2f}), avg. {avg_prefill_speed:.2f} tokens/s")
 
     avg_decode_ms, stdev_decode = avg_and_stdev(x.get_decode_time_ms() for x in run_infos)
-    avg_decode_speed = mean(x.get_prefill_speed() for x in run_infos)
+    avg_decode_speed = mean(x.get_decode_speed() for x in run_infos)
     print(f"Decode: avg. {avg_decode_ms:.2f} ms (stdev {stdev_decode:.2f}), avg. {avg_decode_speed:.2f} tokens/s")
 
     avg_e2e_decode_speed = mean(x.get_e2e_decode_speed() for x in run_infos)

--- a/apps/language_models/scripts/vicuna.py
+++ b/apps/language_models/scripts/vicuna.py
@@ -1949,7 +1949,10 @@ class BenchmarkRunInfo:
     token_times_ms : list[float]
 
     def get_prefill_speed(self) -> float:
-        return self.num_prompt_tokens / miliseconds_to_seconds(self.prefill_time_ms)
+        seconds = miliseconds_to_seconds(self.prefill_time_ms)
+        if seconds == 0.0:
+            return float('inf')
+        return self.num_prompt_tokens / seconds
 
     def num_generated_tokens(self) -> int:
         return len(self.token_times_ms)
@@ -1958,16 +1961,25 @@ class BenchmarkRunInfo:
         return sum(self.token_times_ms)
 
     def get_decode_speed(self) -> float:
-        return self.num_generated_tokens() / miliseconds_to_seconds(self.get_decode_time_ms())
+        seconds = miliseconds_to_seconds(self.get_decode_time_ms())
+        if seconds == 0.0:
+            return float('inf')
+        return self.num_generated_tokens() / seconds
 
     def get_e2e_time_ms(self) -> float:
         return self.prefill_time_ms + self.get_decode_time_ms()
 
     def get_e2e_decode_speed(self) -> float:
-        return self.num_generated_tokens() / miliseconds_to_seconds(self.get_e2e_time_ms())
+        seconds = miliseconds_to_seconds(self.get_e2e_time_ms())
+        if seconds == 0.0:
+            return float('inf')
+        return self.num_generated_tokens() / seconds
 
     def get_e2e_token_processing_speed(self) -> float:
-        return (self.num_prompt_tokens + self.num_generated_tokens()) / miliseconds_to_seconds(self.get_e2e_time_ms())
+        seconds = miliseconds_to_seconds(self.get_e2e_time_ms())
+        if seconds == 0.0:
+            return float('inf')
+        return (self.num_prompt_tokens + self.num_generated_tokens()) / seconds
 
     def print(self) -> None:
         total_tokens = self.num_prompt_tokens + self.num_generated_tokens()

--- a/apps/language_models/scripts/vicuna.py
+++ b/apps/language_models/scripts/vicuna.py
@@ -2121,7 +2121,7 @@ if __name__ == "__main__":
             prompt = args.system_prompt + user_prompt
             history = [[user_prompt, ""]]
 
-        prompt_token_count = 1 # TODO
+        prompt_token_count = len(vic.tokenizer(prompt).input_ids)
         total_time_ms = 0.0  # In order to avoid divide by zero error
         prefill_time_ms = 0
         is_first = True


### PR DESCRIPTION
- Move statistics out of the main loop
- Calculate the input prompt token count. Note that this includes the stop token, e.g., 'Hi' is counted as 2 tokens.
- Add 'end-to-end' numbers
- Switch the main display unit from s to ms
- Start measuring time at 0

The new print format looks like this:
```
Number of iterations: 5
Num tokens: 1 (prompt), 512 (generated), 513 (total)
Prefill: avg. 0.01 ms (stdev 0.00), avg. 97428.99 tokens/s
Decode: avg. 4840.44 ms (stdev 28.80), avg. 97428.99 tokens/s
Decode end-2-end: avg. 105.78 tokens/s (w/o prompt), avg. 105.98 (w/ prompt)
```