### PR TITLE
Fix typo in default_rocm_arch

### DIFF
--- a/shark/iree_utils/gpu_utils.py
+++ b/shark/iree_utils/gpu_utils.py
@@ -104,7 +104,7 @@ def get_rocm_device_arch(device_num=0, extra_args=[]):
         print(f"Found ROCm device arch : {arch_in_device_dump}")
         return arch_in_device_dump
 
-    default_rocm_arch = "gfx_1100"
+    default_rocm_arch = "gfx1100"
     print(
         "Did not find ROCm architecture from `--iree-rocm-target-chip` flag"
         "\n or from `iree-run-module --dump_devices=rocm` command."


### PR DESCRIPTION
The correct name for the architecture is gfx1100, not gfx_1100.
System is Debian testing, rocm 5.7, XFX MERC310 RX 7900 XTX
rocminfo output:
```
*******                  
Agent 2                  
*******                  
  Name:                    gfx1100                            
  Uuid:                    GPU-4b980329224432b7               
  Marketing Name:          AMD Radeon RX 7900 XTX             
  Vendor Name:             AMD                                
  Feature:                 KERNEL_DISPATCH                    
  Profile:                 BASE_PROFILE                       
  Float Round Mode:        NEAR
--truncated--
```

SHARK before:
```
Configuring for device:rocm
could not execute `iree-run-module --dump_devices=rocm`
Did not find ROCm architecture from `--iree-rocm-target-chip` flag
 or from `iree-run-module --dump_devices=rocm` command.
Using gfx_1100 as ROCm arch for compilation.
Traceback (most recent call last):
--snipped--
File "SHARK/shark.venv/lib/python3.11/site-packages/iree/compiler/tools/binaries.py", line 200, in invoke_immediate
    raise CompilerToolError(process)
iree.compiler.tools.binaries.CompilerToolError: Error invoking IREE compiler tool iree-compile
Error code: -6
Diagnostics:
'gfx_1100' is not a recognized processor for this target (ignoring processor)
'gfx_1100' is not a recognized processor for this target (ignoring processor)
```

SHARK after:
```
Configuring for device:rocm
could not execute `iree-run-module --dump_devices=rocm`
Did not find ROCm architecture from `--iree-rocm-target-chip` flag
 or from `iree-run-module --dump_devices=rocm` command.
Using gfx1100 as ROCm arch for compilation.
Saved vmfb in SHARK/apps/stable_diffusion/web/euler_step_1_512_512_rocm_fp16.vmfb.
Loading module SHARK/apps/stable_diffusion/web/euler_step_1_512_512_rocm_fp16.vmfb...
use_tuned? sharkify: False
_1_64_512_512_fp16_stable-diffusion-2-1-base
--works--
```
