### PR TITLE
(Studio 1.0) Setup a separate `shark1.venv` for Shark-1.0

### DIFF
--- a/setup_venv.ps1
+++ b/setup_venv.ps1
@@ -7,13 +7,13 @@
   It checks the Python version installed and installs any required build
   dependencies into a Python virtual environment.
   If that environment does not exist, it creates it.
-  
+
 .PARAMETER update-src
   git pulls latest version
 
 .PARAMETER force
   removes and recreates venv to force update of all dependencies
-  
+
 .EXAMPLE
   .\setup_venv.ps1 --force
 
@@ -39,11 +39,11 @@ if ($arguments -eq "--force"){
         Write-Host "deactivating..."
         Deactivate
     }
-    
-    if (Test-Path .\shark.venv\) {
+
+    if (Test-Path .\shark1.venv\) {
         Write-Host "removing and recreating venv..."
-        Remove-Item .\shark.venv -Force -Recurse
-        if (Test-Path .\shark.venv\) {
+        Remove-Item .\shark1.venv -Force -Recurse
+        if (Test-Path .\shark1.venv\) {
             Write-Host 'could not remove .\shark-venv - please try running ".\setup_venv.ps1 --force" again!'
             exit 1
         }
@@ -83,9 +83,9 @@ if (!($PyVer -like "*3.11*") -and !($p -like "*3.11*")) # if 3.11 is not in any 
 
 Write-Host "Installing Build Dependencies"
 # make sure we really use 3.11 from list, even if it's not the default.
-if ($NULL -ne $PyVer) {py -3.11 -m venv .\shark.venv\}
-else {python -m venv .\shark.venv\}
-.\shark.venv\Scripts\activate
+if ($NULL -ne $PyVer) {py -3.11 -m venv .\shark1.venv\}
+else {python -m venv .\shark1.venv\}
+.\shark1.venv\Scripts\activate
 python -m pip install --upgrade pip
 pip install wheel
 pip install -r requirements.txt
@@ -94,4 +94,4 @@ pip install --upgrade -f https://nod-ai.github.io/SRT/pip-release-links.html ire
 Write-Host "Building SHARK..."
 pip install -e . -f https://llvm.github.io/torch-mlir/package-index/ -f https://nod-ai.github.io/SRT/pip-release-links.html
 Write-Host "Build and installation completed successfully"
-Write-Host "Source your venv with ./shark.venv/Scripts/activate"
+Write-Host "Source your venv with ./shark1.venv/Scripts/activate"

--- a/setup_venv.sh
+++ b/setup_venv.sh
@@ -5,7 +5,7 @@
 # Environment variables used by the script.
 # PYTHON=$PYTHON3.10 ./setup_venv.sh  #pass a version of $PYTHON to use
 # VENV_DIR=myshark.venv #create a venv called myshark.venv
-# SKIP_VENV=1 #Don't create and activate a Python venv. Use the current environment. 
+# SKIP_VENV=1 #Don't create and activate a Python venv. Use the current environment.
 # USE_IREE=1 #use stock IREE instead of Nod.ai's SHARK build
 # IMPORTER=1 #Install importer deps
 # BENCHMARK=1 #Install benchmark deps
@@ -35,7 +35,7 @@ fi
 if [[ "$SKIP_VENV" != "1" ]]; then
   if [[ -z "${CONDA_PREFIX}" ]]; then
     # Not a conda env. So create a new VENV dir
-    VENV_DIR=${VENV_DIR:-shark.venv}
+    VENV_DIR=${VENV_DIR:-shark1.venv}
     echo "Using pip venv.. Setting up venv dir: $VENV_DIR"
     $PYTHON -m venv "$VENV_DIR" || die "Could not create venv."
     source "$VENV_DIR/bin/activate" || die "Could not activate venv"


### PR DESCRIPTION
*This is for the SHARK-1.0 branch **only**, and any potential branches from that, do *not* merge into main branch*

### Motivation

I need a working SHARK 1.0 whilst SHARK 2.0 is being constructed, and I still have the draft of #2015 I'm working on for SHARK 1.0.  So I need separate .venvs for `main/studio_sd2` and `SHARK-1.0` branches.

Having a `setup_venv` on the SHARK-1.0 branch that creates/maintains a separately named .venv, means I can just run that and not worry I've broken the .venv for the other branches.

### Changes

* Updates setup_venv.ps1 to create and use ./shark1.venv/
* Updates setup_venv.sh to default to creating ./shark1.venv/

### Possible Problems/Concerns

* I haven't tested the `setup_venv.sh` change, someone on Linux/Mac will need to check that.
* I'm assuming we want to keep the main branch .venv as `./shark.venv/`
* I had something much more clever checking git commits and such and deciding which .venv to setup, but then I realised that was pointless, since anything not descended from SHARK-1.0 can just use the current `setup_venv` unaltered.
* Still need to remember to activate the right .venv when switching branches (git hook?)
