### PR TITLE
Relocate quantized matmul reassociation flag

### DIFF
--- a/apps/shark_studio/api/llm.py
+++ b/apps/shark_studio/api/llm.py
@@ -106,7 +106,7 @@ class LanguageModel:
             frontend="torch",
             external_weight_file=self.external_weight_file,
             write_to=self.vmfb_name,
-            extra_args=["--iree-global-opt-enable-quantized-matmul-reassociation"]
+            extra_args=["--iree-global-opt-enable-quantized-matmul-reassociation"],
         )
         # TODO: delete the temp file
 

--- a/apps/shark_studio/api/llm.py
+++ b/apps/shark_studio/api/llm.py
@@ -106,6 +106,7 @@ class LanguageModel:
             frontend="torch",
             external_weight_file=self.external_weight_file,
             write_to=self.vmfb_name,
+            extra_args=["--iree-global-opt-enable-quantized-matmul-reassociation"]
         )
         # TODO: delete the temp file
 

--- a/shark/iree_utils/compile_utils.py
+++ b/shark/iree_utils/compile_utils.py
@@ -43,7 +43,6 @@ def get_iree_device_args(device, extra_args=[]):
             get_iree_cpu_args()
             + u_kernel_flag
             + stack_size_flag
-            + ["--iree-global-opt-enable-quantized-matmul-reassociation"]
         )
     if device == "cuda":
         from shark.iree_utils.gpu_utils import get_iree_gpu_args


### PR DESCRIPTION
This flag should be a model/use-case specific addition, not a default CPU compile flag.

We may need to add it to llama2 if it's required for compilation.