### PR TITLE
(Shark 1.0) UI/SD Some UX improvements for SDXL

### DIFF
--- a/apps/stable_diffusion/src/pipelines/pipeline_shark_stable_diffusion_txt2img.py
+++ b/apps/stable_diffusion/src/pipelines/pipeline_shark_stable_diffusion_txt2img.py
@@ -56,6 +56,13 @@ class Text2ImagePipeline(StableDiffusionPipeline):
             scheduler, sd_model, import_mlir, use_lora, lora_strength, ondemand
         )
 
+    @classmethod
+    def favored_base_models(cls, model_id):
+        return [
+            "stabilityai/stable-diffusion-2-1",
+            "CompVis/stable-diffusion-v1-4",
+        ]
+
     def prepare_latents(
         self,
         batch_size,

--- a/apps/stable_diffusion/src/pipelines/pipeline_shark_stable_diffusion_txt2img_sdxl.py
+++ b/apps/stable_diffusion/src/pipelines/pipeline_shark_stable_diffusion_txt2img_sdxl.py
@@ -60,6 +60,19 @@ class Text2ImageSDXLPipeline(StableDiffusionPipeline):
         )
         self.is_fp32_vae = is_fp32_vae
 
+    @classmethod
+    def favored_base_models(cls, model_id):
+        if "turbo" in model_id:
+            return [
+                "stabilityai/sdxl-turbo",
+                "stabilityai/stable-diffusion-xl-base-1.0",
+            ]
+        else:
+            return [
+                "stabilityai/stable-diffusion-xl-base-1.0",
+                "stabilityai/sdxl-turbo",
+            ]
+
     def prepare_latents(
         self,
         batch_size,

--- a/apps/stable_diffusion/src/pipelines/pipeline_shark_stable_diffusion_utils.py
+++ b/apps/stable_diffusion/src/pipelines/pipeline_shark_stable_diffusion_utils.py
@@ -94,6 +94,10 @@ class StableDiffusionPipeline:
             self.unload_unet()
             self.tokenizer = get_tokenizer()
 
+    def favored_base_models(cls, model_id):
+        # all base models can be candidate base models for unet compilation
+        return None
+
     def load_clip(self):
         if self.text_encoder is not None:
             return
@@ -667,6 +671,9 @@ class StableDiffusionPipeline:
         is_upscaler = cls.__name__ in ["UpscalerPipeline"]
         is_sdxl = cls.__name__ in ["Text2ImageSDXLPipeline"]
 
+        print(f"model_id", model_id)
+        print(f"ckpt_loc", ckpt_loc)
+        print(f"favored_base_models:", cls.favored_base_models(model_id))
         sd_model = SharkifyStableDiffusionModel(
             model_id,
             ckpt_loc,
@@ -687,6 +694,9 @@ class StableDiffusionPipeline:
             use_lora=use_lora,
             lora_strength=lora_strength,
             use_quantize=use_quantize,
+            favored_base_models=cls.favored_base_models(
+                model_id if model_id != "" else ckpt_loc
+            ),
         )
 
         if cls.__name__ in ["UpscalerPipeline"]:

--- a/apps/stable_diffusion/web/ui/txt2img_sdxl_ui.py
+++ b/apps/stable_diffusion/web/ui/txt2img_sdxl_ui.py
@@ -153,6 +153,7 @@ def txt2img_sdxl_inf(
             if args.hf_model_id
             else "stabilityai/stable-diffusion-xl-base-1.0"
         )
+
         global_obj.set_schedulers(get_schedulers(model_id))
         scheduler_obj = global_obj.get_scheduler(scheduler)
         if global_obj.get_cfg_obj().ondemand:
@@ -280,12 +281,14 @@ with gr.Blocks(title="Text-to-Image-SDXL", theme=theme) as txt2img_sdxl_web:
                                 label=f"VAE Models",
                                 info=t2i_sdxl_vae_info,
                                 elem_id="custom_model",
-                                value="None",
+                                value="madebyollin/sdxl-vae-fp16-fix",
                                 choices=[
                                     None,
                                     "madebyollin/sdxl-vae-fp16-fix",
                                 ]
-                                + get_custom_model_files("vae"),
+                                + get_custom_model_files(
+                                    "vae", custom_checkpoint_type="sdxl"
+                                ),
                                 allow_custom_value=True,
                                 scale=4,
                             )
@@ -375,7 +378,7 @@ with gr.Blocks(title="Text-to-Image-SDXL", theme=theme) as txt2img_sdxl_web:
                         height = gr.Slider(
                             512,
                             1024,
-                            value=1024,
+                            value=768,
                             step=256,
                             label="Height",
                             visible=True,
@@ -384,7 +387,7 @@ with gr.Blocks(title="Text-to-Image-SDXL", theme=theme) as txt2img_sdxl_web:
                         width = gr.Slider(
                             512,
                             1024,
-                            value=1024,
+                            value=768,
                             step=256,
                             label="Width",
                             visible=True,

--- a/apps/stable_diffusion/web/ui/txt2img_ui.py
+++ b/apps/stable_diffusion/web/ui/txt2img_ui.py
@@ -212,6 +212,10 @@ def txt2img_inf(
                 use_lora=args.use_lora,
                 lora_strength=args.lora_strength,
                 ondemand=args.ondemand,
+                valid_base_models=[
+                    "stabilityai/stable-diffusion-2-1",
+                    "CompVis/stable-diffusion-v1-4",
+                ],
             )
         )
 


### PR DESCRIPTION
### Motivation

I tripped over some things when running running the `juggernautXL_v7Rundiffusion` model from the SDXL tab. This tweaks the UI tab with more immediately functional defaults, and tries to reduce the number of failed attempts at unet base model determination when doing initial .vmfb compilation, eliminating some cases where the wrong base model could be chosen. 

### Changes

* SDXL Tab
  * Filter VAEs in dropdown in the same manner as models.
  * Set default VAE selection to 'madebyollin/sdxl-vae-fp16-fix'.
  * Set default image size to 768x768 to match current Vulkan constraints
* SharkifySDModel Base Unet Model Determination.
  * Alway use the model_to_run as the base model for unet, if that model is a base model defined in base_model.json. Skips looping through all possible base models before that model is defined in the file, whilst attempting to compile for them.
  * Allow SharkSDPipelines to define a 'favor_base_models' classmethod, answering a list of sane base model names for the pipeline. Exclude base models not in that list from compilation attempts when trying to determine a base unet model.
  *  Add a 'favor_base_models' method for both Normal and SDXL Txt2Img Pipelines. Define the method as answering 'None' in the base class, so this additional filtering is not applied for other Pipeline types.
  
### Possible Problems/Concerns

* I'm not 100% convinced that 'favor_base_models' needs to be a classmethod, but the existing interaction between the pipelines and SharkifyStableDiffusionModel turned out hairy enough to make my head hurt trying to work out where an instance method would go or be called from.
* Doesn't fix sending parameters from Output Gallery to SDXL tab. This was my other main annoyance beyond the (not fixable for Shark 1.0) compilation memory and time requirements.
* If the wrong base model is already set in variants.json this won't correct it.