### PR TITLE
(Shark-1) UI: Fix 'keyword argument' error in txt2img

### DIFF
--- a/apps/stable_diffusion/web/ui/txt2img_ui.py
+++ b/apps/stable_diffusion/web/ui/txt2img_ui.py
@@ -212,10 +212,6 @@ def txt2img_inf(
                 use_lora=args.use_lora,
                 lora_strength=args.lora_strength,
                 ondemand=args.ondemand,
-                valid_base_models=[
-                    "stabilityai/stable-diffusion-2-1",
-                    "CompVis/stable-diffusion-v1-4",
-                ],
             )
         )
 


### PR DESCRIPTION
### Motivation

Looks like I left a keyword argument that shouldn't have been there in my last PR #2057 that got merged, breaking Text2Image.


### Changes

* Removes the incorrect valid_base_models keywoard argument left in text2img_inf