### PR TITLE
(Shark 1.0) Fix setup_venv.ps1 not finding pinned torch-mlir

### DIFF
--- a/package-index-torch-mlir.html
+++ b/package-index-torch-mlir.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html><head>
+<meta http-equiv="content-type" content="text/html; charset=UTF-8"></head><body>
+    <a href="https://github.com/llvm/torch-mlir/releases/download/snapshot-20231210.1048/torch-2.2.0.dev20231204%2Bcpu-cp311-cp311-linux_x86_64.whl">torch-2.2.0.dev20231204+cpu-cp311-cp311-linux_x86_64.whl</a><br>
+    <a href="https://github.com/llvm/torch-mlir/releases/download/snapshot-20231210.1048/torch-2.2.0.dev20231204%2Bcpu-cp311-cp311-win_amd64.whl">torch-2.2.0.dev20231204+cpu-cp311-cp311-win_amd64.whl</a><br>
+    <a href="https://github.com/llvm/torch-mlir/releases/download/snapshot-20231213.1048/torch-2.2.0.dev20231204%2Bcpu-cp38-cp38-linux_x86_64.whl">torch-2.2.0.dev20231204+cpu-cp38-cp38-linux_x86_64.whl</a><br>
+    <a href="https://github.com/llvm/torch-mlir/releases/download/snapshot-20231210.1048/torch-2.2.0.dev20231204-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl">torch-2.2.0.dev20231204-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl</a><br>
+    <a href="https://github.com/llvm/torch-mlir/releases/download/snapshot-20231210.1048/torch-2.2.0.dev20231204-cp311-none-macosx_10_9_x86_64.whl">torch-2.2.0.dev20231204-cp311-none-macosx_10_9_x86_64.whl</a><br>
+    <a href="https://github.com/llvm/torch-mlir/releases/download/snapshot-20231210.1048/torch_mlir-20231210.1048-cp311-cp311-linux_aarch64.whl">torch_mlir-20231210.1048-cp311-cp311-linux_aarch64.whl</a><br>
+    <a href="https://github.com/llvm/torch-mlir/releases/download/snapshot-20231210.1048/torch_mlir-20231210.1048-cp311-cp311-linux_x86_64.whl">torch_mlir-20231210.1048-cp311-cp311-linux_x86_64.whl</a><br>
+    <a href="https://github.com/llvm/torch-mlir/releases/download/snapshot-20231210.1048/torch_mlir-20231210.1048-cp311-cp311-macosx_11_0_universal2.whl">torch_mlir-20231210.1048-cp311-cp311-macosx_11_0_universal2.whl</a><br>
+    <a href="https://github.com/llvm/torch-mlir/releases/download/snapshot-20231210.1048/torch_mlir-20231210.1048-cp311-cp311-win_amd64.whl">torch_mlir-20231210.1048-cp311-cp311-win_amd64.whl</a><br>
+    <a href="https://github.com/llvm/torch-mlir/releases/download/snapshot-20231210.1048/torch_mlir-20231210.1048-cp38-cp38-linux_x86_64.whl">torch_mlir-20231210.1048-cp38-cp38-linux_x86_64.whl</a><br>
+</body></html>

--- a/setup_venv.ps1
+++ b/setup_venv.ps1
@@ -89,9 +89,9 @@ else {python -m venv .\shark1.venv\}
 python -m pip install --upgrade pip
 pip install wheel
 pip install -r requirements.txt
-pip install --pre torch-mlir==20231210.* torchvision torch --extra-index-url https://download.pytorch.org/whl/nightly/cpu -f https://llvm.github.io/torch-mlir/package-index/
+pip install --pre torch-mlir==20231210.* torchvision torch --extra-index-url https://download.pytorch.org/whl/nightly/cpu -f .\package-index-torch-mlir.html
 pip install --upgrade -f https://nod-ai.github.io/SRT/pip-release-links.html iree-compiler==20231212.* iree-runtime==20231212.*
 Write-Host "Building SHARK..."
-pip install -e . -f https://llvm.github.io/torch-mlir/package-index/ -f https://nod-ai.github.io/SRT/pip-release-links.html
+pip install -e . -f .\package-index-torch-mlir.html -f https://nod-ai.github.io/SRT/pip-release-links.html
 Write-Host "Build and installation completed successfully"
 Write-Host "Source your venv with ./shark1.venv/Scripts/activate"


### PR DESCRIPTION
Addresses #2061 

### Motivation

The version of torch-mlir pinned by d35288e seems to have dropped off of https://llvm.github.io/torch-mlir/package-index/ so `.\setup-venv.ps1` fails to install it.

### Changes

* Adds a local file equivalent of https://llvm.github.io/torch-mlir/package-index/ containing links to the pinned torch_mlir versions (links taken from the torch-mlir releases github page).
* Use the local file instead of the real package index in setup_venv.ps1.

### Possible Problems/Concerns

* I would be entirely unsurprised if this is completely the wrong way to handle this.
* Does change anything for the `setup-venv.sh` script as the original commit didn't touch that.