### PR TITLE
(Shark 1.0) SD: Fix inpaint (+others) breakage on sharkification

### DIFF
--- a/apps/stable_diffusion/src/pipelines/pipeline_shark_stable_diffusion_utils.py
+++ b/apps/stable_diffusion/src/pipelines/pipeline_shark_stable_diffusion_utils.py
@@ -94,6 +94,7 @@ class StableDiffusionPipeline:
             self.unload_unet()
             self.tokenizer = get_tokenizer()
 
+    @classmethod
     def favored_base_models(cls, model_id):
         # all base models can be candidate base models for unet compilation
         return None
@@ -671,9 +672,6 @@ class StableDiffusionPipeline:
         is_upscaler = cls.__name__ in ["UpscalerPipeline"]
         is_sdxl = cls.__name__ in ["Text2ImageSDXLPipeline"]
 
-        print(f"model_id", model_id)
-        print(f"ckpt_loc", ckpt_loc)
-        print(f"favored_base_models:", cls.favored_base_models(model_id))
         sd_model = SharkifyStableDiffusionModel(
             model_id,
             ckpt_loc,


### PR DESCRIPTION
### Motivation

Inpainting and (presumably other non txt2img operations) is currently breaking at the point where a `SharkifyStableDiffusionModel` is constructed for the appropriate SD pipeline.

### Changes

* Add the @classmethod decorator to the base implementation of `favored_base_models`. This stops running any SD pipeline that does not have a specific implementation of the method (everything but txt2img and txt2img_sdxl), breaking at the Sharkification stage.