### PR TITLE
Studio2/SD/UI: Improve various parts of the UI for Stable Diffusion

### DIFF
--- a/apps/shark_studio/web/index.py
+++ b/apps/shark_studio/web/index.py
@@ -1,4 +1,6 @@
 from multiprocessing import Process, freeze_support
+from PIL import Image
+
 import os
 import time
 import sys
@@ -71,6 +73,10 @@ def launch_webui(address):
 
 def webui():
     from apps.shark_studio.modules.shared_cmd_opts import cmd_opts
+    from apps.shark_studio.web.ui.utils import (
+        nodicon_loc,
+        nodlogo_loc,
+    )
 
     launch_api = cmd_opts.api
     initialize.initialize()
@@ -134,6 +140,7 @@ def webui():
         return os.path.join(base_path, relative_path)
 
     dark_theme = resource_path("ui/css/sd_dark_theme.css")
+    gradio_workarounds = resource_path("ui/js/sd_gradio_workarounds.js")
 
     # from apps.shark_studio.web.ui import load_ui_from_script
 
@@ -158,8 +165,19 @@ def webui():
         )
 
     with gr.Blocks(
-        css=dark_theme, analytics_enabled=False, title="Shark Studio 2.0 Beta"
+        css=dark_theme,
+        js=gradio_workarounds,
+        analytics_enabled=False,
+        title="Shark Studio 2.0 Beta",
     ) as studio_web:
+        nod_logo = Image.open(nodlogo_loc)
+        gr.Image(
+            value=nod_logo,
+            show_label=False,
+            interactive=False,
+            elem_id="tab_bar_logo",
+            show_download_button=False,
+        )
         with gr.Tabs() as tabs:
             # NOTE: If adding, removing, or re-ordering tabs, make sure that they
             # have a unique id that doesn't clash with any of the other tabs,
@@ -189,6 +207,7 @@ def webui():
         inbrowser=True,
         server_name="0.0.0.0",
         server_port=cmd_opts.server_port,
+        favicon_path=nodicon_loc,
     )
 
 

--- a/apps/shark_studio/web/ui/css/sd_dark_theme.css
+++ b/apps/shark_studio/web/ui/css/sd_dark_theme.css
@@ -117,12 +117,21 @@ body {
     height: 100% !important;
 }
 
-/* display in full width for desktop devices */
+/* display in full width for desktop devices, but see below */
 @media (min-width: 1536px)
 {
     .gradio-container {
         max-width: var(--size-full) !important;
     }
+}
+
+/* media rules in custom css are don't appear to be applied in
+   gradio versions > 4.7, so we have to define a class which
+   we will manually need add and remove using javascript.
+   Remove this once this fixed in gradio.
+*/
+.gradio-container-size-full {
+    max-width: var(--size-full) !important;
 }
 
 .gradio-container .contain {
@@ -303,6 +312,14 @@ footer {
     min-height: 89vh !important;
 }
 
+.sd-right-panel {
+    min-height: 87vh !important;
+}
+
+.sd-right-panel .fill {
+    flex: 1;
+}
+
 /* don't stretch non-square images to be square, breaking their aspect ratio */
 #outputgallery_gallery .thumbnail-item.thumbnail-lg > img {
     object-fit: contain !important;
@@ -314,11 +331,27 @@ footer {
     width: 100%;
 }
 
-#top_logo.logo_centered img{
+#top_logo.logo_centered img {
     object-fit: scale-down;
     position: absolute;
     width: 80%;
     top: 50%;
     left: 50%;
     transform: translate(-50%, -50%);
+}
+
+#tab_bar_logo {
+    overflow: visible !important;
+    border-width: 0 !important;
+    height: 0px !important;
+    padding: 0;
+    margin: 0;
+}
+
+#tab_bar_logo .image-container {
+    object-fit: scale-down;
+    position: absolute !important;
+    top: 14px;
+    right: 0px;
+    height: 36px;
 }

--- a/apps/shark_studio/web/ui/css/sd_dark_theme.css
+++ b/apps/shark_studio/web/ui/css/sd_dark_theme.css
@@ -313,7 +313,7 @@ footer {
 }
 
 .sd-right-panel {
-    min-height: 87vh !important;
+    min-height: 84vh !important;
 }
 
 .sd-right-panel .fill {

--- a/apps/shark_studio/web/ui/css/sd_dark_theme.css
+++ b/apps/shark_studio/web/ui/css/sd_dark_theme.css
@@ -191,6 +191,7 @@ footer {
     aspect-ratio: unset;
     max-height: calc(55vh - (2 * var(--spacing-lg)));
 }
+/* fix width and height of gallery items when on very large desktop screens, but see below */
 @media (min-width: 1921px) {
     /* Force a 768px_height + 4px_margin_height + navbar_height for the gallery */
     #gallery .grid-wrap, #gallery .preview{
@@ -202,6 +203,20 @@ footer {
         max-height: 770px !important;
     }
 }
+
+/* media rules in custom css are don't appear to be applied in
+   gradio versions > 4.7, so we have to define classes which
+   we will manually need add and remove using javascript.
+   Remove this once this fixed in gradio.
+*/
+.gallery-force-height768 .grid-wrap, .gallery-force-height768 .preview {
+    min-height: calc(768px + 4px + var(--size-14)) !important;
+    max-height: calc(768px + 4px + var(--size-14)) !important;
+}
+.gallery-limit-height768 .thumbnail-item.thumbnail-lg {
+    max-height: 770px !important;
+}
+
 /* Don't upscale when viewing in solo image mode */
 #gallery .preview img {
     object-fit: scale-down;
@@ -313,7 +328,8 @@ footer {
 }
 
 .sd-right-panel {
-    min-height: 84vh !important;
+    height: calc(100vmin - var(--size-32) - var(--size-10)) !important;
+    overflow-y: scroll;
 }
 
 .sd-right-panel .fill {

--- a/apps/shark_studio/web/ui/js/sd_gradio_workarounds.js
+++ b/apps/shark_studio/web/ui/js/sd_gradio_workarounds.js
@@ -1,0 +1,49 @@
+// workaround gradio after 4.7, not applying any @media rules form the custom .css file
+
+() => {
+    console.log(`innerWidth: ${window.innerWidth}` )
+
+    // 1536px rules
+
+    const mediaQuery1536 = window.matchMedia('(min-width: 1536px)')
+
+    function handleWidth1536(event) {
+
+        // display in full width for desktop devices
+        document.querySelectorAll(".gradio-container")
+            .forEach( (node) => {
+                if (event.matches) {
+                    node.classList.add("gradio-container-size-full");
+                } else {
+                    node.classList.remove("gradio-container-size-full")
+                }
+            });
+    }
+
+    mediaQuery1536.addEventListener("change", handleWidth1536);
+    mediaQuery1536.dispatchEvent(new MediaQueryListEvent("change", {matches: window.innerWidth >= 1536}));
+
+    // 1921px rules
+
+    const mediaQuery1921 = window.matchMedia('(min-width: 1921px)')
+
+    function handleWidth1921(event) {
+
+        /* Force a 768px_height + 4px_margin_height + navbar_height for the gallery */
+        /* Limit height to 768px_height + 2px_margin_height for the thumbnails */
+        document.querySelectorAll("#gallery")
+            .forEach( (node) => {
+                if (event.matches) {
+                    node.classList.add("gallery-force-height768");
+                    node.classList.add("gallery-limit-height768");
+                } else {
+                    node.classList.remove("gallery-force-height768");
+                    node.classList.remove("gallery-limit-height768");
+                }
+            });
+    }
+
+    mediaQuery1921.addEventListener("change", handleWidth1921);
+    mediaQuery1921.dispatchEvent(new MediaQueryListEvent("change", {matches: window.innerWidth >= 1921}));
+
+}

--- a/requirements.txt
+++ b/requirements.txt
@@ -26,7 +26,7 @@ parameterized
 accelerate
 scipy
 ftfy
-gradio==4.8.0
+gradio==4.15.0
 altair
 omegaconf
 # 0.3.2 doesn't have binaries for arm64


### PR DESCRIPTION
### Motivation

I have eyes. 🤪 

### Changes

* Update Gradio pin to 4.15.0.
* Port workarounds for Gradio >4.8.0 main container sizing from Shark 1.0.
* Move nod Logo out of the SD tab and onto the top right of the main tab bar.
* Set nod logo icon as the favicon (as current Shark 1.0).
* Create a tabbed right hand panel within the SD UI sized to the viewport height.
* Make Input Image tab 1 in the right hand panel.
* Make Output images, generation log, and  generation buttons, tab 2 in the right hand panel
* Make config JSON display, with config load, save and clear, tab 3 in the right hand panel
* Make gallery  area of the Output tab take up all vertical space the other controls on the tab do not.
* Tidy up the controls on the Config tab somewhat.

(Since https://github.com/nod-ai/SHARK/pull/2074/commits/a9836937817f7a24bdba5c180c49a73873280ff3)
* Move Batch Count, Batch Size, and Repeatable Seeds, off of Left Panel and onto 'Generate' (Tab 2).
* On 'Generate' tab, rename 'Generate Image(s)' button to 'Start', and 'Stop Batch' button to 'Stop'. They are now below the Batch inputs on a Generate tab so don't need the specificity.
* Move Device, Low VRAM, and Precision inputs into their own 'Device Settings' Accordion control. (starts closed)
* Rename 'Custom Weights Checkpoint' to 'Checkpoint Weights'
* Move Checkpoint Weights, VAE Model, Standalone Lora Weights, and Embeddings Options controls, into their own 'Model Weights' Accordion control.  (starts closed)
* Move Denoising Strength, and Resample Type controls into their own 'Input Image Processing' Accordion. (starts closed)
* Move any remaining controls in the 'Advanced Options' Accordion directly onto the left panel, and remove then Accordion.
* Enable the copy button for all text boxes on the SD tab.
* Add emoji/unicode glphs to all top level controls and Accordions on the SD Left Panel.
* Start with the 'Generate' as the initially selected tab in the SD Right Panel, working around Gradio issue #7805

(Since https://github.com/nod-ai/SHARK/pull/2074/commits/61f09e0ce28fb3d2fe0fc0fd28277861adb9d377)
* Set height of right panel using `vmin` rather than `vh`, with explicit affordances for fixed areas above and below.
* Set right panel to `overflow-y: scroll` 
* Port >1920 width Gradio >4.8 CSS workaround from Shark 1.0.

### Definite to do

- [x] Reorganize the left hand side of the UI. (https://github.com/nod-ai/SHARK/pull/2074/commits/a9836937817f7a24bdba5c180c49a73873280ff3)
- ~[ ] Rework the Config Tab to be saner.~
- [x] Improve viewport units use in the CSS (i.e. better affordance for the fixed size elements) (https://github.com/nod-ai/SHARK/commit/61f09e0ce28fb3d2fe0fc0fd28277861adb9d377)
- [x] Disentangle from #2070 if necessary. (https://github.com/nod-ai/SHARK/pull/2074/commits/c598638ab33f9ea4e86c270eb7b14281b44d02c8)
- [x] Port remaining Gradio > 4.8.0 workarounds. (https://github.com/nod-ai/SHARK/commit/61f09e0ce28fb3d2fe0fc0fd28277861adb9d377)
- ~[ ] Some way of moving images from output to input.~ Needs a pipeline I can successfully run before it makes sense for me to work on this.

### Maybe to do

- ~[ ] Select saved configs rather than base models. Have a base saved config for each of the current base models.~
- ~[ ] Remove output gallery from main tab and integrate into the SD tab.~
- ~[ ] Implement the #TODO about loading parameters when an input image is selected that has metadata.~
- ~[ ] Stencil editing in input image tab.~

### Possible Problems/Concerns

* The pipeline is not in a state where I can actually run it and test the UI is responding correctly. I can get it as far as "Turbine can't do this on Windows yet" after commenting out bogus, and adding in dummy, keyword arguments in a bunch of places, but that's it.
* ~I've based this off my PR #2070 just for my comfort trying to work on it, so it currently branched off of that stuff. Not ideal from an integration POV.~ Reverted those changes on this branch in https://github.com/nod-ai/SHARK/pull/2074/commits/c598638ab33f9ea4e86c270eb7b14281b44d02c8
* Lots still to do, against what's presumably a moving target.
* I don't know what we're looking with regards to UI tests, and what's sane for python and gradio, so I don't have any so far.
* There is controlnet stuff in the UI code, I don't see it showing up. I haven't looked closely yet.
* Tabs in tabs. Yay! :grimacing:

### Current Screenshot (as at https://github.com/nod-ai/SHARK/pull/2074/commits/a9836937817f7a24bdba5c180c49a73873280ff3)

![shark2_ui_wip2](https://github.com/nod-ai/SHARK/assets/121311569/8ba567b8-11d8-445a-8e4d-5cd6a10bb053)
