### PR TITLE
Studio2/SD: Fix sd pipeline up to "Windows not supported"

### DIFF
--- a/apps/shark_studio/api/sd.py
+++ b/apps/shark_studio/api/sd.py
@@ -96,6 +96,7 @@ class StableDiffusion(SharkPipelineBase):
         num_loras: int = 0,
         import_ir: bool = True,
         is_controlled: bool = False,
+        hf_auth_token=None,
     ):
         self.model_max_length = 77
         self.batch_size = batch_size
@@ -112,7 +113,7 @@ class StableDiffusion(SharkPipelineBase):
             "unet": {
                 "hf_model_name": base_model_id,
                 "unet_model": unet.UnetModel(
-                    hf_model_name=base_model_id, hf_auth_token=None
+                    hf_model_name=base_model_id, hf_auth_token=hf_auth_token
                 ),
                 "batch_size": batch_size,
                 # "is_controlled": is_controlled,
@@ -125,8 +126,8 @@ class StableDiffusion(SharkPipelineBase):
             "vae_encode": {
                 "hf_model_name": base_model_id,
                 "vae_model": vae.VaeModel(
-                    hf_model_name=base_model_id,
-                    custom_vae=custom_vae,
+                    hf_model_name=custom_vae if custom_vae else base_model_id,
+                    hf_auth_token=hf_auth_token,
                 ),
                 "batch_size": batch_size,
                 "height": height,
@@ -136,8 +137,8 @@ class StableDiffusion(SharkPipelineBase):
             "vae_decode": {
                 "hf_model_name": base_model_id,
                 "vae_model": vae.VaeModel(
-                    hf_model_name=base_model_id,
-                    custom_vae=custom_vae,
+                    hf_model_name=custom_vae if custom_vae else base_model_id,
+                    hf_auth_token=hf_auth_token,
                 ),
                 "batch_size": batch_size,
                 "height": height,
@@ -183,7 +184,7 @@ class StableDiffusion(SharkPipelineBase):
                 custom_weights_params, _ = process_custom_pipe_weights(custom_weights)
                 if submodel not in ["clip", "clip2"]:
                     self.static_kwargs[submodel][
-                        "external_weight_file"
+                        "external_weights"
                     ] = custom_weights_params
                 else:
                     self.static_kwargs[submodel]["external_weight_path"] = os.path.join(

--- a/apps/shark_studio/web/configs/default_sd_config.json
+++ b/apps/shark_studio/web/configs/default_sd_config.json
@@ -1,1 +1,28 @@
-{"prompt": ["a photo taken of the front of a super-car drifting on a road near mountains at high speeds with smoke coming off the tires, front angle, front point of view, trees in the mountains of the background, ((sharp focus))"], "negative_prompt": ["watermark, signature, logo, text, lowres, ((monochrome, grayscale)), blurry, ugly, blur, oversaturated, cropped"], "sd_init_image": [null], "height": 512, "width": 512, "steps": 50, "strength": 0.8, "guidance_scale": 7.5, "seed": "-1", "batch_count": 1, "batch_size": 1, "scheduler": "EulerDiscrete", "base_model_id": "stabilityai/stable-diffusion-2-1-base", "custom_weights": "None", "custom_vae": "None", "precision": "fp16", "device": "AMD Radeon RX 7900 XTX => vulkan://0", "ondemand": false, "repeatable_seeds": false, "resample_type": "Nearest Neighbor", "controlnets": {}, "embeddings": {}}
+{
+  "prompt": [
+    "a photo taken of the front of a super-car drifting on a road near mountains at high speeds with smoke coming off the tires, front angle, front point of view, trees in the mountains of the background, ((sharp focus))"
+  ],
+  "negative_prompt": [
+    "watermark, signature, logo, text, lowres, ((monochrome, grayscale)), blurry, ugly, blur, oversaturated, cropped"
+  ],
+  "sd_init_image": [null],
+  "height": 512,
+  "width": 512,
+  "steps": 50,
+  "strength": 0.8,
+  "guidance_scale": 7.5,
+  "seed": "-1",
+  "batch_count": 1,
+  "batch_size": 1,
+  "scheduler": "EulerDiscrete",
+  "base_model_id": "stabilityai/stable-diffusion-2-1-base",
+  "custom_weights": null,
+  "custom_vae": null,
+  "precision": "fp16",
+  "device": "AMD Radeon RX 7900 XTX => vulkan://0",
+  "ondemand": false,
+  "repeatable_seeds": false,
+  "resample_type": "Nearest Neighbor",
+  "controlnets": {},
+  "embeddings": {}
+}

--- a/apps/shark_studio/web/ui/sd.py
+++ b/apps/shark_studio/web/ui/sd.py
@@ -136,6 +136,8 @@ def pull_sd_configs(
                 sd_cfg[arg] = json.loads(sd_args[arg])
             else:
                 sd_cfg[arg] = {}
+        elif arg == "None":
+            sd_cfg[arg] = None
         else:
             sd_cfg[arg] = sd_args[arg]
     return sd_cfg

--- a/apps/shark_studio/web/ui/sd.py
+++ b/apps/shark_studio/web/ui/sd.py
@@ -33,6 +33,8 @@ from apps.shark_studio.modules.img_processing import (
 from apps.shark_studio.modules.shared_cmd_opts import cmd_opts
 from apps.shark_studio.web.ui.utils import (
     nodlogo_loc,
+    none_to_str_none,
+    str_none_to_none,
 )
 from apps.shark_studio.web.utils.state import (
     status_label,
@@ -122,7 +124,7 @@ def pull_sd_configs(
     controlnets,
     embeddings,
 ):
-    sd_args = locals()
+    sd_args = str_none_to_none(locals())
     sd_cfg = {}
     for arg in sd_args:
         if arg in [
@@ -136,15 +138,14 @@ def pull_sd_configs(
                 sd_cfg[arg] = json.loads(sd_args[arg])
             else:
                 sd_cfg[arg] = {}
-        elif arg == "None":
-            sd_cfg[arg] = None
         else:
             sd_cfg[arg] = sd_args[arg]
-    return sd_cfg
+
+    return json.dumps(sd_cfg)
 
 
 def load_sd_cfg(sd_json: dict, load_sd_config: str):
-    new_sd_config = json.loads(view_json_file(load_sd_config))
+    new_sd_config = none_to_str_none(json.loads(view_json_file(load_sd_config)))
     if sd_json:
         for key in new_sd_config:
             sd_json[key] = new_sd_config[key]
@@ -277,9 +278,11 @@ with gr.Blocks(title="Stable Diffusion") as sd_element:
                             label=f"Custom VAE Models",
                             info=sd_vae_info,
                             elem_id="custom_model",
-                            value=os.path.basename(cmd_opts.custom_vae)
-                            if cmd_opts.custom_vae
-                            else "None",
+                            value=(
+                                os.path.basename(cmd_opts.custom_vae)
+                                if cmd_opts.custom_vae
+                                else "None"
+                            ),
                             choices=["None"] + get_checkpoints("vae"),
                             allow_custom_value=True,
                             scale=1,
@@ -626,9 +629,11 @@ with gr.Blocks(title="Stable Diffusion") as sd_element:
                         load_sd_config = gr.FileExplorer(
                             label="Load Config",
                             file_count="single",
-                            root=cmd_opts.configs_path
-                            if cmd_opts.configs_path
-                            else get_configs_path(),
+                            root=(
+                                cmd_opts.configs_path
+                                if cmd_opts.configs_path
+                                else get_configs_path()
+                            ),
                             height=75,
                         )
                         load_sd_config.change(

--- a/apps/shark_studio/web/ui/utils.py
+++ b/apps/shark_studio/web/ui/utils.py
@@ -29,3 +29,15 @@ def hsl_color(alpha: float, start, end):
 
     # Return a CSS HSL string
     return f"hsl({math.floor(result)}, 80%, 35%)"
+
+
+def none_to_str_none(props: dict):
+    for key in props:
+        props[key] = "None" if props[key] == None else props[key]
+    return props
+
+
+def str_none_to_none(props: dict):
+    for key in props:
+        props[key] = None if props[key] == "None" else props[key]
+    return props

--- a/setup_venv.ps1
+++ b/setup_venv.ps1
@@ -7,13 +7,13 @@
   It checks the Python version installed and installs any required build
   dependencies into a Python virtual environment.
   If that environment does not exist, it creates it.
-  
+
 .PARAMETER update-src
   git pulls latest version
 
 .PARAMETER force
   removes and recreates venv to force update of all dependencies
-  
+
 .EXAMPLE
   .\setup_venv.ps1 --force
 
@@ -39,7 +39,7 @@ if ($arguments -eq "--force"){
         Write-Host "deactivating..."
         Deactivate
     }
-    
+
     if (Test-Path .\shark.venv\) {
         Write-Host "removing and recreating venv..."
         Remove-Item .\shark.venv -Force -Recurse
@@ -90,7 +90,6 @@ python -m pip install --upgrade pip
 pip install wheel
 pip install -r requirements.txt
 pip install --pre torch-mlir torchvision torch --extra-index-url https://download.pytorch.org/whl/nightly/cpu -f https://llvm.github.io/torch-mlir/package-index/
-pip install --upgrade -f https://nod-ai.github.io/SRT/pip-release-links.html iree-compiler iree-runtime
 Write-Host "Building SHARK..."
 pip install -e . -f https://llvm.github.io/torch-mlir/package-index/ -f https://nod-ai.github.io/SRT/pip-release-links.html
 Write-Host "Build and installation completed successfully"


### PR DESCRIPTION
_Amongst other things this address #2063 on Windows, but not necessarily in the correct way_

## Motivation

Get running the SD pipeline from the SD UI at least to the point where it breaks because I'm on Windows rather than for other reasons.

## Changes

* Remove separate install of iree-runtime and iree-compile in setup_venv.ps1, and rely on the versions installed via the Turbine requirements.txt. Fixes #2063 for me.
* Replace any "None" strings with python None when pulling the config in the UI.
* Add 'hf_auth_token' param to api StableDiffusion class, defaulting to None, and then pass that in to the various Models where it is required and wasn't already being done before.
* Fix clip custom_weight_params being passed to export_clip_model as "external_weight_file" rather than "external_weights"
* Don't pass non-existing "custom_vae" parameter to the Turbine Vae Model, instead pass custom_vae as the "hf_model_id" if it is set. (this may be wrong in the custom vae case, but stops the code *always* breaking).

## Possible Problems/Concerns

* Looking at the Turbine README, I might have the Fix for #2063 the wrong way round. It's likely that the correct way to do things is to uninstall the version of iree-compiler and iree-runtime that Turbine requires and the do the install from SRT rather than skipping the SRT sourced install.
* As usual with changes to `setup_venv.ps1` I haven't updated the bash script to match, since I'm not in a position to test it.
* As noted, the fix to stop things breaking on the custom_vae parameter not being a thing in the Turbine Model, may not actually make sense if you are using a custom vae.