### PR TITLE
Add *.safetensors to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -183,6 +183,7 @@ generated_imgs/
 # Custom model related artefacts
 variants.json
 /models/
+*.safetensors
 
 # models folder
 apps/stable_diffusion/web/models/


### PR DESCRIPTION
### Motivation

Whilst trying to remove some more blockages to Shark2 generating an image on Windows, I kept ending up with .safetensors files appearing and `git` still noticing them.

### Changes

- shark2 is putting base model .safetensors files in model specific subfolders. Easiest to just ignore .safetensors completely.