### PR TITLE
Studio2/SD/UI: Further sd ui pipeline fixes

### DIFF
--- a/apps/shark_studio/api/sd.py
+++ b/apps/shark_studio/api/sd.py
@@ -120,8 +120,8 @@ class StableDiffusion(SharkPipelineBase):
                 # "num_loras": num_loras,
                 "height": height,
                 "width": width,
-                "precision": precision,
-                "max_length": self.model_max_length,
+                # "precision": precision,
+                # "max_length": self.model_max_length,
             },
             "vae_encode": {
                 "hf_model_name": base_model_id,
@@ -150,7 +150,7 @@ class StableDiffusion(SharkPipelineBase):
         pipe_id_list = [
             safe_name(base_model_id),
             str(batch_size),
-            str(static_kwargs["unet"]["max_length"]),
+            str(self.model_max_length),
             f"{str(height)}x{str(width)}",
             precision,
             self.device,

--- a/apps/shark_studio/web/ui/sd.py
+++ b/apps/shark_studio/web/ui/sd.py
@@ -645,7 +645,7 @@ with gr.Blocks(title="Stable Diffusion") as sd_element:
                                     load_sd_config = gr.FileExplorer(
                                         label="Load Config",
                                         file_count="single",
-                                        root=(
+                                        root_dir=(
                                             cmd_opts.configs_path
                                             if cmd_opts.configs_path
                                             else get_configs_path()
@@ -702,58 +702,6 @@ with gr.Blocks(title="Stable Diffusion") as sd_element:
                                     inputs=[sd_json, sd_config_name],
                                     outputs=[sd_config_name],
                                 )
-                            )
-                        )
-                    with gr.Column(scale=1):
-                        clear_sd_config = gr.ClearButton(
-                            value="Clear Config", size="sm", components=sd_json
-                        )
-                        with gr.Row():
-                            save_sd_config = gr.Button(value="Save Config", size="sm")
-                            sd_config_name = gr.Textbox(
-                                value="Config Name",
-                                info="Name of the file this config will be saved to.",
-                                interactive=True,
-                            )
-                        load_sd_config = gr.FileExplorer(
-                            label="Load Config",
-                            file_count="single",
-                            root=(
-                                cmd_opts.configs_path
-                                if cmd_opts.configs_path
-                                else get_configs_path()
-                            ),
-                            height=75,
-                        )
-                        load_sd_config.change(
-                            fn=load_sd_cfg,
-                            inputs=[sd_json, load_sd_config],
-                            outputs=[
-                                prompt,
-                                negative_prompt,
-                                sd_init_image,
-                                height,
-                                width,
-                                steps,
-                                strength,
-                                guidance_scale,
-                                seed,
-                                batch_count,
-                                batch_size,
-                                scheduler,
-                                base_model_id,
-                                custom_weights,
-                                custom_vae,
-                                precision,
-                                device,
-                                ondemand,
-                                repeatable_seeds,
-                                resample_type,
-                                cnet_config,
-                                embeddings_config,
-                                sd_json,
-                            ],
-                        )
                         save_sd_config.click(
                             fn=save_sd_cfg,
                             inputs=[sd_json, sd_config_name],

--- a/setup_venv.ps1
+++ b/setup_venv.ps1
@@ -89,8 +89,5 @@ else {python -m venv .\shark.venv\}
 python -m pip install --upgrade pip
 pip install wheel
 pip install -r requirements.txt
-pip install --pre torch-mlir torchvision torch --extra-index-url https://download.pytorch.org/whl/nightly/cpu -f https://llvm.github.io/torch-mlir/package-index/
-Write-Host "Building SHARK..."
-pip install -e . -f https://llvm.github.io/torch-mlir/package-index/ -f https://nod-ai.github.io/SRT/pip-release-links.html
-Write-Host "Build and installation completed successfully"
+
 Write-Host "Source your venv with ./shark.venv/Scripts/activate"


### PR DESCRIPTION
### Motivation

On Windows, this gets us all the way to failing in iree compile of SD 2.1 base; per @monorimet this is where we expect it to fail with the current Turbine build.

You will need to `.\setup_venv.ps1 --force` to clear out the conflicting dependencies previously sourced from SRT etc.

### Updates

- Fix merge errors with sd right pane config UI tab.
- Remove non-requirement.txt install/build of torch/mlir/iree/SRT in setup_venv.ps1, fixing "torch.compile not supported on Windows" error.
- Fix gradio deprecation warning for `root=` FileExplorer kwarg.
- Comment out `precision` and `max_length` kwargs being passed to unet, as not yet supported on main Turbine branch. Avoids keyword argument error.

### Possible Problems/Concerns

- As usual I haven't made any changes to `./setup_venv.sh`, as I'm not currently in a position to test that. It may need equivalent changes to `.\setup_venv.ps1`.
- My editor is apparently not auto-wrapping commit messages anymore. 🤦 