### PR TITLE
Studio2/SD/API: Exclude more static_kwargs in StableDiffusion.init for now

### DIFF
--- a/apps/shark_studio/api/sd.py
+++ b/apps/shark_studio/api/sd.py
@@ -103,6 +103,9 @@ class StableDiffusion(SharkPipelineBase):
         self.height = height
         self.width = width
         self.scheduler_obj = {}
+
+        # TODO: Reinstate commented out *kwargs once supported by the relevant
+        # turbine.models
         static_kwargs = {
             "pipe": {
                 "external_weights": "safetensors",
@@ -130,7 +133,7 @@ class StableDiffusion(SharkPipelineBase):
                 "batch_size": batch_size,
                 "height": height,
                 "width": width,
-                "precision": precision,
+                # "precision": precision,
             },
             "vae_decode": {
                 "hf_model_name": base_model_id,
@@ -141,7 +144,7 @@ class StableDiffusion(SharkPipelineBase):
                 "batch_size": batch_size,
                 "height": height,
                 "width": width,
-                "precision": precision,
+                # "precision": precision,
             },
         }
         super().__init__(sd_model_map, base_model_id, static_kwargs, device, import_ir)


### PR DESCRIPTION
### Motivation

Although the changes in #2091 got things to failing at the point of `iree-compile` of unet for me, the merged version considers vae_encode before unet. It turns out vae_encode has a similar problem with including a `precision` argument when main branch `turbine_models.custom_models.sd_inference` doesn't yet include it.

This comments out `precision` for all the blocks in the the `static_kwargs` variable which defines how the the various pipeline models are called, and gets us back to an `iree-compile` failure again.

### Changes

- Comment out precision being set in static_kwargs for vae_encode when setting up a StableDiffusion pipeline
- Comment out precision being set in static_kwargs for vae_decode when setting up a StableDiffusion pipeline

### Possible Problems/Concerns

- This is will need to be reverted once support for `precision` is landed in the Turbine models, I've added a TODO comment saying that.