### PR TITLE
Studio2/SD/UI: Update gradio to 4.19.2 (sd-studio2)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -26,7 +26,7 @@ parameterized
 accelerate
 scipy
 ftfy
-gradio==4.15.0
+gradio==4.19.2
 altair
 omegaconf
 # 0.3.2 doesn't have binaries for arm64


### PR DESCRIPTION
### Motivation

Dependabot wants gradio to go to 4.19.2. This does that for `sd-studio2`.


### Changes

- Move pin for gradio from 4.15 -> 4.19.2 on the sd-studio2 branch

### Possible Problems/Concerns

- There don't appear to be any changes needed other than the version bump. So maybe it would make more sense to just merge back from `main` if that gets updated?