### PR TITLE
Shark-1.0: Update gradio to 4.19.2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -168,6 +168,7 @@ cython_debug/
 *venv/
 shark_tmp/
 *.vmfb
+*.safetensors
 .use-iree
 tank/dict_configs.py
 *.csv

--- a/apps/language_models/langchain/cli.py
+++ b/apps/language_models/langchain/cli.py
@@ -151,9 +151,9 @@ def run_cli(  # for local function:
             eval_vars[eval_func_param_names.index("iinput")] = eval_vars[
                 eval_func_param_names.index("iinput_nochat")
             ] = ""  # no input yet
-            eval_vars[
-                eval_func_param_names.index("context")
-            ] = ""  # no context yet
+            eval_vars[eval_func_param_names.index("context")] = (
+                ""  # no context yet
+            )
 
             # grab other parameters, like langchain_mode
             for k in eval_func_param_names:

--- a/apps/language_models/langchain/create_data.py
+++ b/apps/language_models/langchain/create_data.py
@@ -336,14 +336,16 @@ def test_config_to_json():
                             "\n", ""
                         ),
                     },
-                    {
-                        "prompt_type": "plain",
-                        "instruction": f"<human>: How can I do this: {title}.\n<bot>: Set the {k.replace('_', ' ')} config.toml\n<human>:".replace(
-                            "\n", ""
-                        ),
-                    }
-                    if title and comment
-                    else None,
+                    (
+                        {
+                            "prompt_type": "plain",
+                            "instruction": f"<human>: How can I do this: {title}.\n<bot>: Set the {k.replace('_', ' ')} config.toml\n<human>:".replace(
+                                "\n", ""
+                            ),
+                        }
+                        if title and comment
+                        else None
+                    ),
                     {
                         "prompt_type": "human_bot",
                         "instruction": f"Explain the following expert setting for Driverless AI",

--- a/apps/language_models/langchain/gen.py
+++ b/apps/language_models/langchain/gen.py
@@ -582,9 +582,9 @@ class Langchain:
                 tokenizer,
                 model=base_model,
                 device=0 if self.device == "cuda" else -1,
-                torch_dtype=torch.float16
-                if self.device == "cuda"
-                else torch.float32,
+                torch_dtype=(
+                    torch.float16 if self.device == "cuda" else torch.float32
+                ),
             )
         else:
             assert self.device in ["cuda", "cpu", "mps"], (
@@ -592,9 +592,9 @@ class Langchain:
             )
             model_kwargs = dict(
                 local_files_only=local_files_only,
-                torch_dtype=torch.float16
-                if self.device == "cuda"
-                else torch.float32,
+                torch_dtype=(
+                    torch.float16 if self.device == "cuda" else torch.float32
+                ),
                 resume_download=resume_download,
                 use_auth_token=use_auth_token,
                 trust_remote_code=trust_remote_code,
@@ -628,9 +628,9 @@ class Langchain:
                 # MPT doesn't support spreading over GPUs
                 model_kwargs.update(
                     dict(
-                        device_map={"": gpu_id}
-                        if self.device == "cuda"
-                        else "cpu"
+                        device_map=(
+                            {"": gpu_id} if self.device == "cuda" else "cpu"
+                        )
                     )
                 )
 
@@ -689,17 +689,19 @@ class Langchain:
                 model = PeftModel.from_pretrained(
                     model,
                     lora_weights,
-                    torch_dtype=torch.float16
-                    if self.device == "cuda"
-                    else torch.float32,
+                    torch_dtype=(
+                        torch.float16
+                        if self.device == "cuda"
+                        else torch.float32
+                    ),
                     local_files_only=local_files_only,
                     resume_download=resume_download,
                     use_auth_token=use_auth_token,
                     trust_remote_code=trust_remote_code,
                     offload_folder=offload_folder,
-                    device_map={"": 0}
-                    if self.device == "cuda"
-                    else {"": "cpu"},  # seems to be required
+                    device_map=(
+                        {"": 0} if self.device == "cuda" else {"": "cpu"}
+                    ),  # seems to be required
                 )
             else:
                 with torch.device(self.device):
@@ -716,9 +718,11 @@ class Langchain:
                     model = PeftModel.from_pretrained(
                         model,
                         lora_weights,
-                        torch_dtype=torch.float16
-                        if self.device == "cuda"
-                        else torch.float32,
+                        torch_dtype=(
+                            torch.float16
+                            if self.device == "cuda"
+                            else torch.float32
+                        ),
                         local_files_only=local_files_only,
                         resume_download=resume_download,
                         use_auth_token=use_auth_token,
@@ -1143,9 +1147,9 @@ class Langchain:
                 db=db1,
                 user_path=user_path,
                 detect_user_path_changes_every_query=detect_user_path_changes_every_query,
-                cut_distanct=1.1
-                if langchain_mode in ["wiki_full"]
-                else 1.64,  # FIXME, too arbitrary
+                cut_distanct=(
+                    1.1 if langchain_mode in ["wiki_full"] else 1.64
+                ),  # FIXME, too arbitrary
                 use_openai_embedding=use_openai_embedding,
                 use_openai_model=use_openai_model,
                 hf_embedding_model=hf_embedding_model,
@@ -1523,9 +1527,11 @@ class Langchain:
         examples += [
             [
                 summarize_example1,
-                "Summarize"
-                if prompt_type not in ["plain", "instruct_simple"]
-                else "",
+                (
+                    "Summarize"
+                    if prompt_type not in ["plain", "instruct_simple"]
+                    else ""
+                ),
             ]
             + params_list
         ]
@@ -1548,14 +1554,14 @@ class Langchain:
             ]
             # adjust examples if non-chat mode
             if not chat:
-                example[
-                    eval_func_param_names.index("instruction_nochat")
-                ] = example[eval_func_param_names.index("instruction")]
+                example[eval_func_param_names.index("instruction_nochat")] = (
+                    example[eval_func_param_names.index("instruction")]
+                )
                 example[eval_func_param_names.index("instruction")] = ""
 
-                example[
-                    eval_func_param_names.index("iinput_nochat")
-                ] = example[eval_func_param_names.index("iinput")]
+                example[eval_func_param_names.index("iinput_nochat")] = (
+                    example[eval_func_param_names.index("iinput")]
+                )
                 example[eval_func_param_names.index("iinput")] = ""
             assert len(example) == len(
                 eval_func_param_names

--- a/apps/language_models/langchain/gpt_langchain.py
+++ b/apps/language_models/langchain/gpt_langchain.py
@@ -489,9 +489,9 @@ class GradioInference(LLM):
         chunk = True
         chunk_size = 512
         client_kwargs = dict(
-            instruction=prompt
-            if self.chat_client
-            else "",  # only for chat=True
+            instruction=(
+                prompt if self.chat_client else ""
+            ),  # only for chat=True
             iinput="",  # only for chat=True
             context="",
             # streaming output is supported, loops over and outputs each generation in streaming mode

--- a/apps/language_models/langchain/h2oai_pipeline.py
+++ b/apps/language_models/langchain/h2oai_pipeline.py
@@ -316,9 +316,9 @@ def generate_token(h2ogpt_shark_model, model, tokenizer, **generate_kwargs):
     )
 
     model_kwargs["output_attentions"] = generation_config.output_attentions
-    model_kwargs[
-        "output_hidden_states"
-    ] = generation_config.output_hidden_states
+    model_kwargs["output_hidden_states"] = (
+        generation_config.output_hidden_states
+    )
     model_kwargs["use_cache"] = generation_config.use_cache
 
     input_ids = (

--- a/apps/language_models/langchain/image_captions.py
+++ b/apps/language_models/langchain/image_captions.py
@@ -7,6 +7,7 @@ By default, the loader utilizes the pre-trained BLIP image captioning model.
 https://huggingface.co/Salesforce/blip-image-captioning-base
 
 """
+
 from typing import List, Union, Any, Tuple
 
 import requests

--- a/apps/language_models/langchain/read_wiki_full.py
+++ b/apps/language_models/langchain/read_wiki_full.py
@@ -1,4 +1,5 @@
 """Load Data from a MediaWiki dump xml."""
+
 import ast
 import glob
 import pickle
@@ -105,9 +106,11 @@ class MWDumpDirectLoader(MWDumpLoader):
                     source="https://en.wikipedia.org/wiki/" + title_url,
                     id=page.id,
                     redirect=page.redirect,
-                    views=self.views[page.title]
-                    if self.views is not None
-                    else -1,
+                    views=(
+                        self.views[page.title]
+                        if self.views is not None
+                        else -1
+                    ),
                 )
                 metadata = {k: v for k, v in metadata.items() if v is not None}
                 docs.append(Document(page_content=text, metadata=metadata))

--- a/apps/language_models/src/pipelines/falcon_pipeline.py
+++ b/apps/language_models/src/pipelines/falcon_pipeline.py
@@ -279,16 +279,18 @@ class ShardedFalcon(SharkLLMBase):
         path = shark_module.save_module(
             self.falcon_vmfb_path.parent.absolute(),
             self.falcon_vmfb_path.stem,
-            extra_args=[
-                "--iree-vm-target-truncate-unsupported-floats",
-                "--iree-codegen-check-ir-before-llvm-conversion=false",
-                "--iree-vm-bytecode-module-output-format=flatbuffer-binary",
-            ]
-            + [
-                "--iree-llvmcpu-use-fast-min-max-ops",
-            ]
-            if self.precision == "int4"
-            else [],
+            extra_args=(
+                [
+                    "--iree-vm-target-truncate-unsupported-floats",
+                    "--iree-codegen-check-ir-before-llvm-conversion=false",
+                    "--iree-vm-bytecode-module-output-format=flatbuffer-binary",
+                ]
+                + [
+                    "--iree-llvmcpu-use-fast-min-max-ops",
+                ]
+                if self.precision == "int4"
+                else []
+            ),
             debug=self.debug,
         )
         print("Saved falcon vmfb at ", str(path))
@@ -326,9 +328,11 @@ class ShardedFalcon(SharkLLMBase):
             lm_head,
             [sample_hidden_states],
             "lm_head",
-            device_idx=(0 % num_devices) % args.num_shards
-            if self.device == "rocm"
-            else None,
+            device_idx=(
+                (0 % num_devices) % args.num_shards
+                if self.device == "rocm"
+                else None
+            ),
         )
         shark_lm_head = CompiledLMHeadEmbeddingLayer(shark_lm_head)
 
@@ -340,9 +344,11 @@ class ShardedFalcon(SharkLLMBase):
             word_embedding,
             [sample_input_ids],
             "word_embeddings",
-            device_idx=(1 % num_devices) % args.num_shards
-            if self.device == "rocm"
-            else None,
+            device_idx=(
+                (1 % num_devices) % args.num_shards
+                if self.device == "rocm"
+                else None
+            ),
         )
         shark_word_embedding = CompiledWordEmbeddingsLayer(
             shark_word_embedding
@@ -354,9 +360,11 @@ class ShardedFalcon(SharkLLMBase):
             ln_f,
             [sample_hidden_states],
             "ln_f",
-            device_idx=(2 % num_devices) % args.num_shards
-            if self.device == "rocm"
-            else None,
+            device_idx=(
+                (2 % num_devices) % args.num_shards
+                if self.device == "rocm"
+                else None
+            ),
         )
         shark_ln_f = CompiledLNFEmbeddingLayer(shark_ln_f)
 
@@ -458,9 +466,9 @@ class ShardedFalcon(SharkLLMBase):
         )
 
         model_kwargs["output_attentions"] = generation_config.output_attentions
-        model_kwargs[
-            "output_hidden_states"
-        ] = generation_config.output_hidden_states
+        model_kwargs["output_hidden_states"] = (
+            generation_config.output_hidden_states
+        )
         model_kwargs["use_cache"] = generation_config.use_cache
 
         input_ids = (
@@ -790,16 +798,18 @@ class UnshardedFalcon(SharkLLMBase):
         path = shark_module.save_module(
             self.falcon_vmfb_path.parent.absolute(),
             self.falcon_vmfb_path.stem,
-            extra_args=[
-                "--iree-vm-target-truncate-unsupported-floats",
-                "--iree-codegen-check-ir-before-llvm-conversion=false",
-                "--iree-vm-bytecode-module-output-format=flatbuffer-binary",
-            ]
-            + [
-                "--iree-llvmcpu-use-fast-min-max-ops",
-            ]
-            if self.precision == "int4"
-            else [],
+            extra_args=(
+                [
+                    "--iree-vm-target-truncate-unsupported-floats",
+                    "--iree-codegen-check-ir-before-llvm-conversion=false",
+                    "--iree-vm-bytecode-module-output-format=flatbuffer-binary",
+                ]
+                + [
+                    "--iree-llvmcpu-use-fast-min-max-ops",
+                ]
+                if self.precision == "int4"
+                else []
+            ),
             debug=self.debug,
         )
         print("Saved falcon vmfb at ", str(path))
@@ -859,9 +869,9 @@ class UnshardedFalcon(SharkLLMBase):
         batch_size = inputs_tensor.shape[0]
 
         model_kwargs["output_attentions"] = generation_config.output_attentions
-        model_kwargs[
-            "output_hidden_states"
-        ] = generation_config.output_hidden_states
+        model_kwargs["output_hidden_states"] = (
+            generation_config.output_hidden_states
+        )
         model_kwargs["use_cache"] = generation_config.use_cache
 
         input_ids = (

--- a/apps/language_models/src/pipelines/minigpt4_utils/blip_processors.py
+++ b/apps/language_models/src/pipelines/minigpt4_utils/blip_processors.py
@@ -4,6 +4,7 @@
  SPDX-License-Identifier: BSD-3-Clause
  For full license text, see the LICENSE_Lavis file in the repo root or https://opensource.org/licenses/BSD-3-Clause
 """
+
 from omegaconf import OmegaConf
 from torchvision import transforms
 from torchvision.transforms.functional import InterpolationMode

--- a/apps/language_models/src/pipelines/minigpt4_utils/eva_vit.py
+++ b/apps/language_models/src/pipelines/minigpt4_utils/eva_vit.py
@@ -383,9 +383,9 @@ class VisionTransformer(nn.Module):
         super().__init__()
         self.image_size = img_size
         self.num_classes = num_classes
-        self.num_features = (
-            self.embed_dim
-        ) = embed_dim  # num_features for consistency with other models
+        self.num_features = self.embed_dim = (
+            embed_dim  # num_features for consistency with other models
+        )
 
         self.patch_embed = PatchEmbed(
             img_size=img_size,
@@ -429,9 +429,11 @@ class VisionTransformer(nn.Module):
                     drop_path=dpr[i],
                     norm_layer=norm_layer,
                     init_values=init_values,
-                    window_size=self.patch_embed.patch_shape
-                    if use_rel_pos_bias
-                    else None,
+                    window_size=(
+                        self.patch_embed.patch_shape
+                        if use_rel_pos_bias
+                        else None
+                    ),
                 )
                 for i in range(depth)
             ]

--- a/apps/shark_studio/web/ui/chat.py
+++ b/apps/shark_studio/web/ui/chat.py
@@ -379,9 +379,9 @@ def llm_chat_api(InputData: dict):
     end_time = dt.now().strftime("%Y%m%d%H%M%S%f")
     return {
         "id": end_time,
-        "object": "chat.completion"
-        if is_chat_completion_api
-        else "text_completion",
+        "object": (
+            "chat.completion" if is_chat_completion_api else "text_completion"
+        ),
         "created": int(end_time),
         "choices": choices,
     }

--- a/apps/stable_diffusion/src/pipelines/pipeline_shark_stable_diffusion_outpaint.py
+++ b/apps/stable_diffusion/src/pipelines/pipeline_shark_stable_diffusion_outpaint.py
@@ -480,12 +480,16 @@ class OutpaintPipeline(StableDiffusionPipeline):
                 (
                     expand_pixels + mask_blur if is_left else 0,
                     expand_pixels + mask_blur if is_top else 0,
-                    msk.width - expand_pixels - mask_blur
-                    if is_right
-                    else res_w,
-                    msk.height - expand_pixels - mask_blur
-                    if is_bottom
-                    else res_h,
+                    (
+                        msk.width - expand_pixels - mask_blur
+                        if is_right
+                        else res_w
+                    ),
+                    (
+                        msk.height - expand_pixels - mask_blur
+                        if is_bottom
+                        else res_h
+                    ),
                 ),
                 fill="black",
             )

--- a/apps/stable_diffusion/src/pipelines/pipeline_shark_stable_diffusion_utils.py
+++ b/apps/stable_diffusion/src/pipelines/pipeline_shark_stable_diffusion_utils.py
@@ -796,9 +796,9 @@ class StableDiffusionPipeline:
         text_embeddings, uncond_embeddings = get_weighted_text_embeddings(
             pipe=self,
             prompt=prompt,
-            uncond_prompt=negative_prompt
-            if do_classifier_free_guidance
-            else None,
+            uncond_prompt=(
+                negative_prompt if do_classifier_free_guidance else None
+            ),
             max_embeddings_multiples=max_embeddings_multiples,
         )
         # SHARK: we are not using num_images_per_prompt

--- a/apps/stable_diffusion/src/schedulers/sd_schedulers.py
+++ b/apps/stable_diffusion/src/schedulers/sd_schedulers.py
@@ -56,42 +56,40 @@ def get_schedulers(model_id):
         model_id,
         subfolder="scheduler",
     )
-    schedulers[
-        "DPMSolverMultistep"
-    ] = DPMSolverMultistepScheduler.from_pretrained(
-        model_id, subfolder="scheduler", algorithm_type="dpmsolver"
+    schedulers["DPMSolverMultistep"] = (
+        DPMSolverMultistepScheduler.from_pretrained(
+            model_id, subfolder="scheduler", algorithm_type="dpmsolver"
+        )
     )
-    schedulers[
-        "DPMSolverMultistep++"
-    ] = DPMSolverMultistepScheduler.from_pretrained(
-        model_id, subfolder="scheduler", algorithm_type="dpmsolver++"
+    schedulers["DPMSolverMultistep++"] = (
+        DPMSolverMultistepScheduler.from_pretrained(
+            model_id, subfolder="scheduler", algorithm_type="dpmsolver++"
+        )
     )
-    schedulers[
-        "DPMSolverMultistepKarras"
-    ] = DPMSolverMultistepScheduler.from_pretrained(
-        model_id,
-        subfolder="scheduler",
-        use_karras_sigmas=True,
+    schedulers["DPMSolverMultistepKarras"] = (
+        DPMSolverMultistepScheduler.from_pretrained(
+            model_id,
+            subfolder="scheduler",
+            use_karras_sigmas=True,
+        )
     )
-    schedulers[
-        "DPMSolverMultistepKarras++"
-    ] = DPMSolverMultistepScheduler.from_pretrained(
-        model_id,
-        subfolder="scheduler",
-        algorithm_type="dpmsolver++",
-        use_karras_sigmas=True,
+    schedulers["DPMSolverMultistepKarras++"] = (
+        DPMSolverMultistepScheduler.from_pretrained(
+            model_id,
+            subfolder="scheduler",
+            algorithm_type="dpmsolver++",
+            use_karras_sigmas=True,
+        )
     )
-    schedulers[
-        "DPMSolverSDEKarras++"
-    ] = DPMSolverMultistepScheduler.from_pretrained(
-        model_id,
-        subfolder="scheduler",
-        algorithm_type="sde-dpmsolver++",
-        use_karras_sigmas=True,
+    schedulers["DPMSolverSDEKarras++"] = (
+        DPMSolverMultistepScheduler.from_pretrained(
+            model_id,
+            subfolder="scheduler",
+            algorithm_type="sde-dpmsolver++",
+            use_karras_sigmas=True,
+        )
     )
-    schedulers[
-        "DPMSolverSDE++"
-    ] = DPMSolverMultistepScheduler.from_pretrained(
+    schedulers["DPMSolverSDE++"] = DPMSolverMultistepScheduler.from_pretrained(
         model_id,
         subfolder="scheduler",
         algorithm_type="sde-dpmsolver++",
@@ -100,39 +98,39 @@ def get_schedulers(model_id):
         model_id,
         subfolder="scheduler",
     )
-    schedulers[
-        "EulerAncestralDiscrete"
-    ] = EulerAncestralDiscreteScheduler.from_pretrained(
-        model_id,
-        subfolder="scheduler",
+    schedulers["EulerAncestralDiscrete"] = (
+        EulerAncestralDiscreteScheduler.from_pretrained(
+            model_id,
+            subfolder="scheduler",
+        )
     )
     schedulers["DEISMultistep"] = DEISMultistepScheduler.from_pretrained(
         model_id,
         subfolder="scheduler",
     )
-    schedulers[
-        "SharkEulerDiscrete"
-    ] = SharkEulerDiscreteScheduler.from_pretrained(
-        model_id,
-        subfolder="scheduler",
+    schedulers["SharkEulerDiscrete"] = (
+        SharkEulerDiscreteScheduler.from_pretrained(
+            model_id,
+            subfolder="scheduler",
+        )
     )
-    schedulers[
-        "SharkEulerAncestralDiscrete"
-    ] = SharkEulerAncestralDiscreteScheduler.from_pretrained(
-        model_id,
-        subfolder="scheduler",
+    schedulers["SharkEulerAncestralDiscrete"] = (
+        SharkEulerAncestralDiscreteScheduler.from_pretrained(
+            model_id,
+            subfolder="scheduler",
+        )
     )
-    schedulers[
-        "DPMSolverSinglestep"
-    ] = DPMSolverSinglestepScheduler.from_pretrained(
-        model_id,
-        subfolder="scheduler",
+    schedulers["DPMSolverSinglestep"] = (
+        DPMSolverSinglestepScheduler.from_pretrained(
+            model_id,
+            subfolder="scheduler",
+        )
     )
-    schedulers[
-        "KDPM2AncestralDiscrete"
-    ] = KDPM2AncestralDiscreteScheduler.from_pretrained(
-        model_id,
-        subfolder="scheduler",
+    schedulers["KDPM2AncestralDiscrete"] = (
+        KDPM2AncestralDiscreteScheduler.from_pretrained(
+            model_id,
+            subfolder="scheduler",
+        )
     )
     schedulers["HeunDiscrete"] = HeunDiscreteScheduler.from_pretrained(
         model_id,

--- a/apps/stable_diffusion/src/schedulers/shark_eulerancestraldiscrete.py
+++ b/apps/stable_diffusion/src/schedulers/shark_eulerancestraldiscrete.py
@@ -89,9 +89,7 @@ class SharkEulerAncestralDiscreteScheduler(EulerAncestralDiscreteScheduler):
                 self, noise_pred, latent, sigma, sigma_from, sigma_to, noise
             ):
                 sigma_up = (
-                    sigma_to**2
-                    * (sigma_from**2 - sigma_to**2)
-                    / sigma_from**2
+                    sigma_to**2 * (sigma_from**2 - sigma_to**2) / sigma_from**2
                 ) ** 0.5
                 sigma_down = (sigma_to**2 - sigma_up**2) ** 0.5
                 dt = sigma_down - sigma
@@ -108,9 +106,7 @@ class SharkEulerAncestralDiscreteScheduler(EulerAncestralDiscreteScheduler):
                 self, noise_pred, sigma, sigma_from, sigma_to, latent, noise
             ):
                 sigma_up = (
-                    sigma_to**2
-                    * (sigma_from**2 - sigma_to**2)
-                    / sigma_from**2
+                    sigma_to**2 * (sigma_from**2 - sigma_to**2) / sigma_from**2
                 ) ** 0.5
                 sigma_down = (sigma_to**2 - sigma_up**2) ** 0.5
                 dt = sigma_down - sigma

--- a/apps/stable_diffusion/src/utils/utils.py
+++ b/apps/stable_diffusion/src/utils/utils.py
@@ -669,10 +669,12 @@ def processLoRA(model, use_lora, splitting_prefix, lora_strength):
                     state_dict[f"{stem}up.weight"],
                     state_dict[f"{stem}down.weight"],
                     state_dict.get(f"{stem}mid.weight", None),
-                    state_dict[f"{weight_key}.alpha"]
-                    / state_dict[f"{stem}up.weight"].shape[1]
-                    if f"{weight_key}.alpha" in state_dict
-                    else 1.0,
+                    (
+                        state_dict[f"{weight_key}.alpha"]
+                        / state_dict[f"{stem}up.weight"].shape[1]
+                        if f"{weight_key}.alpha" in state_dict
+                        else 1.0
+                    ),
                 )
 
     # Directly update weight in model
@@ -977,9 +979,9 @@ def save_output_img(output_img, img_seed, extra_info=None):
         "CFG_SCALE": args.guidance_scale,
         "PRECISION": args.precision,
         "STEPS": args.steps,
-        "HEIGHT": args.height
-        if not args.use_hiresfix
-        else args.hiresfix_height,
+        "HEIGHT": (
+            args.height if not args.use_hiresfix else args.hiresfix_height
+        ),
         "WIDTH": args.width if not args.use_hiresfix else args.hiresfix_width,
         "MAX_LENGTH": args.max_length,
         "OUTPUT": out_img_path,

--- a/apps/stable_diffusion/web/api/sdapi_v1.py
+++ b/apps/stable_diffusion/web/api/sdapi_v1.py
@@ -130,9 +130,11 @@ def options_api():
     return {
         "samples_save": True,
         "samples_format": frozen_args.output_img_format,
-        "sd_model_checkpoint": os.path.basename(frozen_args.ckpt_loc)
-        if frozen_args.ckpt_loc
-        else frozen_args.hf_model_id,
+        "sd_model_checkpoint": (
+            os.path.basename(frozen_args.ckpt_loc)
+            if frozen_args.ckpt_loc
+            else frozen_args.hf_model_id
+        ),
         "sd_lora": frozen_args.use_lora,
         "sd_vae": frozen_args.custom_vae or "Automatic",
         "enable_pnginfo": frozen_args.write_metadata_to_png,

--- a/apps/stable_diffusion/web/index.py
+++ b/apps/stable_diffusion/web/index.py
@@ -439,7 +439,7 @@ if __name__ == "__main__":
             )
             register_outputgallery_sendto_button(
                 outputgallery_sendto_txt2img_sdxl,
-                0,
+                13,
                 [outputgallery_filename],
                 [txt2img_sdxl_png_info_img, tabs],
             )

--- a/apps/stable_diffusion/web/ui/h2ogpt.py
+++ b/apps/stable_diffusion/web/ui/h2ogpt.py
@@ -83,9 +83,9 @@ def chat(curr_system_message, history, device, precision):
 
         langchain = Langchain(device, precision)
         h2ogpt_model, h2ogpt_tokenizer, _ = langchain.get_model(
-            load_4bit=True
-            if device == "cuda"
-            else False,  # load model in 4bit if device is cuda to save memory
+            load_4bit=(
+                True if device == "cuda" else False
+            ),  # load model in 4bit if device is cuda to save memory
             load_gptq="",
             use_safetensors=False,
             infer_devices=True,
@@ -207,9 +207,11 @@ with gr.Blocks(title="DocuChat") as h2ogpt_web:
         print(supported_devices)
         device = gr.Dropdown(
             label="Device",
-            value=supported_devices[0]
-            if enabled
-            else "Only CUDA Supported for now",
+            value=(
+                supported_devices[0]
+                if enabled
+                else "Only CUDA Supported for now"
+            ),
             choices=supported_devices,
             interactive=enabled,
             allow_custom_value=True,

--- a/apps/stable_diffusion/web/ui/img2img_ui.py
+++ b/apps/stable_diffusion/web/ui/img2img_ui.py
@@ -355,9 +355,11 @@ with gr.Blocks(title="Image-to-Image") as img2img_web:
                         label=f"Models",
                         info="Select, or enter HuggingFace Model ID or Civitai model download URL",
                         elem_id="custom_model",
-                        value=os.path.basename(args.ckpt_loc)
-                        if args.ckpt_loc
-                        else "stabilityai/stable-diffusion-2-1-base",
+                        value=(
+                            os.path.basename(args.ckpt_loc)
+                            if args.ckpt_loc
+                            else "stabilityai/stable-diffusion-2-1-base"
+                        ),
                         choices=get_custom_model_files() + predefined_models,
                         allow_custom_value=True,
                         scale=2,
@@ -371,9 +373,11 @@ with gr.Blocks(title="Image-to-Image") as img2img_web:
                         label=f"Custom VAE Models",
                         info=i2i_vae_info,
                         elem_id="custom_model",
-                        value=os.path.basename(args.custom_vae)
-                        if args.custom_vae
-                        else "None",
+                        value=(
+                            os.path.basename(args.custom_vae)
+                            if args.custom_vae
+                            else "None"
+                        ),
                         choices=["None"] + get_custom_model_files("vae"),
                         allow_custom_value=True,
                         scale=1,

--- a/apps/stable_diffusion/web/ui/inpaint_ui.py
+++ b/apps/stable_diffusion/web/ui/inpaint_ui.py
@@ -312,9 +312,11 @@ with gr.Blocks(title="Inpainting") as inpaint_web:
                         label=f"Models",
                         info="Select, or enter HuggingFace Model ID or Civitai model download URL",
                         elem_id="custom_model",
-                        value=os.path.basename(args.ckpt_loc)
-                        if args.ckpt_loc
-                        else "stabilityai/stable-diffusion-2-inpainting",
+                        value=(
+                            os.path.basename(args.ckpt_loc)
+                            if args.ckpt_loc
+                            else "stabilityai/stable-diffusion-2-inpainting"
+                        ),
                         choices=get_custom_model_files(
                             custom_checkpoint_type="inpainting"
                         )
@@ -331,9 +333,11 @@ with gr.Blocks(title="Inpainting") as inpaint_web:
                         label=f"Custom VAE Models",
                         info=inpaint_vae_info,
                         elem_id="custom_model",
-                        value=os.path.basename(args.custom_vae)
-                        if args.custom_vae
-                        else "None",
+                        value=(
+                            os.path.basename(args.custom_vae)
+                            if args.custom_vae
+                            else "None"
+                        ),
                         choices=["None"] + get_custom_model_files("vae"),
                         allow_custom_value=True,
                         scale=1,

--- a/apps/stable_diffusion/web/ui/lora_train_ui.py
+++ b/apps/stable_diffusion/web/ui/lora_train_ui.py
@@ -45,9 +45,11 @@ with gr.Blocks(title="Lora Training") as lora_train_web:
                                 label=f"Models",
                                 info=train_lora_model_info,
                                 elem_id="custom_model",
-                                value=os.path.basename(args.ckpt_loc)
-                                if args.ckpt_loc
-                                else "None",
+                                value=(
+                                    os.path.basename(args.ckpt_loc)
+                                    if args.ckpt_loc
+                                    else "None"
+                                ),
                                 choices=["None"]
                                 + get_custom_model_files()
                                 + predefined_models,

--- a/apps/stable_diffusion/web/ui/outpaint_ui.py
+++ b/apps/stable_diffusion/web/ui/outpaint_ui.py
@@ -259,9 +259,11 @@ with gr.Blocks(title="Outpainting") as outpaint_web:
                         label=f"Models",
                         info="Select, or enter HuggingFace Model ID or Civitai model download URL",
                         elem_id="custom_model",
-                        value=os.path.basename(args.ckpt_loc)
-                        if args.ckpt_loc
-                        else "stabilityai/stable-diffusion-2-inpainting",
+                        value=(
+                            os.path.basename(args.ckpt_loc)
+                            if args.ckpt_loc
+                            else "stabilityai/stable-diffusion-2-inpainting"
+                        ),
                         choices=get_custom_model_files(
                             custom_checkpoint_type="inpainting"
                         )
@@ -278,9 +280,11 @@ with gr.Blocks(title="Outpainting") as outpaint_web:
                         label=f"Custom VAE Models",
                         info=outpaint_vae_info,
                         elem_id="custom_model",
-                        value=os.path.basename(args.custom_vae)
-                        if args.custom_vae
-                        else "None",
+                        value=(
+                            os.path.basename(args.custom_vae)
+                            if args.custom_vae
+                            else "None"
+                        ),
                         choices=["None"] + get_custom_model_files("vae"),
                         allow_custom_value=True,
                         scale=1,

--- a/apps/stable_diffusion/web/ui/stablelm_ui.py
+++ b/apps/stable_diffusion/web/ui/stablelm_ui.py
@@ -372,9 +372,9 @@ def llm_chat_api(InputData: dict):
     end_time = dt.now().strftime("%Y%m%d%H%M%S%f")
     return {
         "id": end_time,
-        "object": "chat.completion"
-        if is_chat_completion_api
-        else "text_completion",
+        "object": (
+            "chat.completion" if is_chat_completion_api else "text_completion"
+        ),
         "created": int(end_time),
         "choices": choices,
     }

--- a/apps/stable_diffusion/web/ui/txt2img_sdxl_ui.py
+++ b/apps/stable_diffusion/web/ui/txt2img_sdxl_ui.py
@@ -261,9 +261,11 @@ with gr.Blocks(title="Text-to-Image-SDXL", theme=theme) as txt2img_sdxl_web:
                                 label=f"Models",
                                 info="Select, or enter HuggingFace Model ID or Civitai model download URL",
                                 elem_id="custom_model",
-                                value=os.path.basename(args.ckpt_loc)
-                                if args.ckpt_loc
-                                else "stabilityai/stable-diffusion-xl-base-1.0",
+                                value=(
+                                    os.path.basename(args.ckpt_loc)
+                                    if args.ckpt_loc
+                                    else "stabilityai/stable-diffusion-xl-base-1.0"
+                                ),
                                 choices=predefined_sdxl_models
                                 + get_custom_model_files(
                                     custom_checkpoint_type="sdxl"
@@ -617,6 +619,7 @@ with gr.Blocks(title="Text-to-Image-SDXL", theme=theme) as txt2img_sdxl_web:
                 height,
                 txt2img_sdxl_custom_model,
                 lora_weights,
+                lora_strength,
                 custom_vae,
             ],
             outputs=[
@@ -631,6 +634,7 @@ with gr.Blocks(title="Text-to-Image-SDXL", theme=theme) as txt2img_sdxl_web:
                 height,
                 txt2img_sdxl_custom_model,
                 lora_weights,
+                lora_strength,
                 custom_vae,
             ],
         )

--- a/apps/stable_diffusion/web/ui/txt2img_ui.py
+++ b/apps/stable_diffusion/web/ui/txt2img_ui.py
@@ -380,9 +380,11 @@ def load_settings():
     return [
         loaded_settings.get(
             "txt2img_custom_model",
-            os.path.basename(args.ckpt_loc)
-            if args.ckpt_loc
-            else "stabilityai/stable-diffusion-2-1-base",
+            (
+                os.path.basename(args.ckpt_loc)
+                if args.ckpt_loc
+                else "stabilityai/stable-diffusion-2-1-base"
+            ),
         ),
         loaded_settings.get(
             "custom_vae",
@@ -858,6 +860,7 @@ with gr.Blocks(title="Text-to-Image", css=dark_theme) as txt2img_web:
                 height,
                 txt2img_custom_model,
                 lora_weights,
+                lora_strength,
                 custom_vae,
             ],
             outputs=[

--- a/apps/stable_diffusion/web/ui/upscaler_ui.py
+++ b/apps/stable_diffusion/web/ui/upscaler_ui.py
@@ -280,9 +280,11 @@ with gr.Blocks(title="Upscaler") as upscaler_web:
                         label=f"Models",
                         info="Select, or enter HuggingFace Model ID or Civitai model download URL",
                         elem_id="custom_model",
-                        value=os.path.basename(args.ckpt_loc)
-                        if args.ckpt_loc
-                        else "stabilityai/stable-diffusion-x4-upscaler",
+                        value=(
+                            os.path.basename(args.ckpt_loc)
+                            if args.ckpt_loc
+                            else "stabilityai/stable-diffusion-x4-upscaler"
+                        ),
                         choices=get_custom_model_files(
                             custom_checkpoint_type="upscaler"
                         )
@@ -299,9 +301,11 @@ with gr.Blocks(title="Upscaler") as upscaler_web:
                         label=f"Custom VAE Models",
                         info=upscaler_vae_info,
                         elem_id="custom_model",
-                        value=os.path.basename(args.custom_vae)
-                        if args.custom_vae
-                        else "None",
+                        value=(
+                            os.path.basename(args.custom_vae)
+                            if args.custom_vae
+                            else "None"
+                        ),
                         choices=["None"] + get_custom_model_files("vae"),
                         allow_custom_value=True,
                         scale=1,

--- a/apps/stable_diffusion/web/ui/utils.py
+++ b/apps/stable_diffusion/web/ui/utils.py
@@ -370,7 +370,7 @@ default_configs = {
             visible=False,
             interactive=False,
             value=False,
-        )
+        ),
     ],
     "stabilityai/stable-diffusion-xl-base-1.0": [
         gr.Textbox(label="Prompt", interactive=True, visible=True),

--- a/apps/stable_diffusion/web/utils/metadata/png_metadata.py
+++ b/apps/stable_diffusion/web/utils/metadata/png_metadata.py
@@ -156,6 +156,7 @@ def import_png_metadata(
     height,
     custom_model,
     custom_lora,
+    custom_lora_strength,
     custom_vae,
 ):
     try:

--- a/requirements.txt
+++ b/requirements.txt
@@ -26,7 +26,7 @@ diffusers==0.24.0
 accelerate
 scipy
 ftfy
-gradio==4.12.0
+gradio==4.19.2
 altair
 omegaconf
 # 0.3.2 doesn't have binaries for arm64


### PR DESCRIPTION
### Motivation

Dependabot wants an update of `gradio` to 4.19.2. This changed the behaviour of gradio change events slightly and revealed a bug that previously didn't trigger. That bug caused a crash when doing .png import for txt2img and sdxl txt2imge, or sending to either of those tabs.

### Changes

- Move pin for gradio from 4.12 -> 4.19.2
- Fix png import txt2img/txt2img_sdxl event handling for gradio 4.19.2

### Possible Problems/Concerns

- black also wanted a bunch of reformatting of existing code, because new black version + new year. So a lot of files not involved in the gradio update are also changed.
