### PR TITLE
SHARK-1.0: Fixes to requirements for newer dependency versions

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -45,6 +45,9 @@ langchain
 einops # for zoedepth
 pydantic==2.4.1 # pin until pyinstaller-hooks-contrib works with beta versions
 
+# mpmath sub-dependency, breaks sympy sub-dependency as of (1.4.0a0) version
+mpmath==1.3.0
+
 # Keep PyInstaller at the end. Sometimes Windows Defender flags it but most folks can continue even if it errors
 pefile
 pyinstaller

--- a/setup_venv.ps1
+++ b/setup_venv.ps1
@@ -89,7 +89,8 @@ else {python -m venv .\shark1.venv\}
 python -m pip install --upgrade pip
 pip install wheel
 pip install -r requirements.txt
-pip install --pre torch-mlir==20231210.* torchvision torch --extra-index-url https://download.pytorch.org/whl/nightly/cpu -f .\package-index-torch-mlir.html
+pip install torchvision --no-deps -f https://download.pytorch.org/whl/nightly/cpu/torchvision/
+pip install --pre torch-mlir==20231210.* torch --extra-index-url https://download.pytorch.org/whl/nightly/cpu -f .\package-index-torch-mlir.html
 pip install --upgrade -f https://nod-ai.github.io/SRT/pip-release-links.html iree-compiler==20231212.* iree-runtime==20231212.*
 Write-Host "Building SHARK..."
 pip install -e . -f .\package-index-torch-mlir.html -f https://nod-ai.github.io/SRT/pip-release-links.html


### PR DESCRIPTION
### Motivation

Setting up a `venv` for SHARK-1.0 was getting to be a right pain, due to #2095 and there apparently no longer being any common torch version that fits both torchvision and the version of torch-mlir we have pinned for SHARK-1.0.


### Changes

- Adds mpmath==1.3.0 as a direct requirement to workaround a sympy dependency issue.
- Change setup_venv.ps1 to install torchvision --nodeps. This avoids a failure to find any common torch version dependency between the pinned torch-mlir version and torchvision after a long search. This also more closely matches what setup_venv.sh does.

### Possible Problems/Concerns

- Still complains about the dependency conflict around torchvision, but at least it doesn't now check every listed version of torchvision at the index url before giving up.
- Shouldn't we just `pip --freeze` everything and pin it all for Shark-1.0,given the current dev effort is all on Studio2/Turbine?