### PR TITLE
Update _IREE_TARGET_MAP to return 'vulkan-spirv' for 'vulkan'

### DIFF
--- a/shark/iree_utils/_common.py
+++ b/shark/iree_utils/_common.py
@@ -91,7 +91,7 @@ _IREE_TARGET_MAP = {
     "cpu-task": "llvm-cpu",
     "cpu-sync": "llvm-cpu",
     "cuda": "cuda",
-    "vulkan": "vulkan",
+    "vulkan": "vulkan-spirv",
     "metal": "metal",
     "rocm": "rocm",
     "intel-gpu": "opencl-spirv",
@@ -122,9 +122,7 @@ def check_device_drivers(device):
         )
         return True
     except RuntimeError as re:
-        print(
-            f"[ERR] Failed to get driver for {device} with error:\n{repr(re)}"
-        )
+        print(f"[ERR] Failed to get driver for {device} with error:\n{repr(re)}")
         return True
 
     # Unknown device. We assume drivers are installed.


### PR DESCRIPTION
### Motivation

After updating the .venv, `iree` started complaining that that `vulkan` was a not a valid output backend.

### Changes

- Change target passed to iree for vulkan from 'vulkan' to 'vulkan-spriv', as 'vulkan' is not a valid value for --iree-hal-target-backends with the current iree compiler.

### Possible Problems/Concerns

- https://github.com/openxla/iree/pull/16591 implies that using --iree-hal-target-backends is not going to be the right approach going forward, but it is what `ireec.compilestr` uses, which is what Shark is calling in turn 🤷 