### PR TITLE
Fix _IREE_TARGET_MAP (#2103)

### DIFF
--- a/shark/iree_utils/_common.py
+++ b/shark/iree_utils/_common.py
@@ -91,7 +91,7 @@ _IREE_TARGET_MAP = {
     "cpu-task": "llvm-cpu",
     "cpu-sync": "llvm-cpu",
     "cuda": "cuda",
-    "vulkan": "vulkan",
+    "vulkan": "vulkan-spirv",
     "metal": "metal",
     "rocm": "rocm",
     "intel-gpu": "opencl-spirv",
@@ -122,9 +122,7 @@ def check_device_drivers(device):
         )
         return True
     except RuntimeError as re:
-        print(
-            f"[ERR] Failed to get driver for {device} with error:\n{repr(re)}"
-        )
+        print(f"[ERR] Failed to get driver for {device} with error:\n{repr(re)}")
         return True
 
     # Unknown device. We assume drivers are installed.


### PR DESCRIPTION
- Change target passed to iree for vulkan from 'vulkan' to 'vulkan-spriv', as 'vulkan' is not a valid value for --iree-hal-target-backends with the current iree compiler.