### PR TITLE
Add a few requirements for ensured parity with turbine-models requirements.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -23,6 +23,7 @@ parameterized
 
 # Add transformers, diffusers and scipy since it most commonly used
 #accelerate is now required for diffusers import from ckpt.
+scipy
 accelerate
 ftfy
 gradio==4.29.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -23,8 +23,9 @@ parameterized
 
 # Add transformers, diffusers and scipy since it most commonly used
 #accelerate is now required for diffusers import from ckpt.
-scipy
 accelerate
+scipy
+torchsde
 ftfy
 gradio==4.29.0
 altair

--- a/requirements.txt
+++ b/requirements.txt
@@ -25,7 +25,8 @@ parameterized
 #accelerate is now required for diffusers import from ckpt.
 accelerate
 scipy
-torchsde
+transformers==4.37.1
+torchsde # Required for Stable Diffusion SDE schedulers.
 ftfy
 gradio==4.29.0
 altair


### PR DESCRIPTION
This should fix the downstream tests for SHARK in SHARK-Turbine.